### PR TITLE
Add node versioning and migration system

### DIFF
--- a/src/workflow_engine/__init__.py
+++ b/src/workflow_engine/__init__.py
@@ -17,6 +17,10 @@ from .core import (
     IntegerValue,
     JSON,
     JSONValue,
+    Migration,
+    MigrationError,
+    MigrationNotFoundError,
+    MigrationValidationError,
     Node,
     NodeException,
     NullValue,
@@ -32,6 +36,7 @@ from .core import (
     Workflow,
     WorkflowErrors,
     WorkflowValue,
+    migration_registry,
 )
 
 __all__ = [
@@ -51,6 +56,10 @@ __all__ = [
     "IntegerValue",
     "JSON",
     "JSONValue",
+    "Migration",
+    "MigrationError",
+    "MigrationNotFoundError",
+    "MigrationValidationError",
     "Node",
     "NodeException",
     "NullValue",
@@ -66,4 +75,5 @@ __all__ = [
     "Workflow",
     "WorkflowErrors",
     "WorkflowValue",
+    "migration_registry",
 ]

--- a/src/workflow_engine/core/__init__.py
+++ b/src/workflow_engine/core/__init__.py
@@ -3,6 +3,16 @@ from .context import Context
 from .edge import Edge, InputEdge, OutputEdge
 from .error import NodeException, UserException, WorkflowErrors
 from .execution import ExecutionAlgorithm
+from .migration import (
+    Migration,
+    MigrationError,
+    MigrationNotFoundError,
+    MigrationRegistry,
+    MigrationRunner,
+    MigrationValidationError,
+    migration_registry,
+    migration_runner,
+)
 from .node import Empty, Node, NodeTypeInfo, Params
 from .values import (
     JSON,
@@ -44,6 +54,12 @@ __all__ = [
     "IntegerValue",
     "JSON",
     "JSONValue",
+    "Migration",
+    "MigrationError",
+    "MigrationNotFoundError",
+    "MigrationRegistry",
+    "MigrationRunner",
+    "MigrationValidationError",
     "Node",
     "NodeException",
     "NodeTypeInfo",
@@ -61,4 +77,6 @@ __all__ = [
     "Workflow",
     "WorkflowErrors",
     "WorkflowValue",
+    "migration_registry",
+    "migration_runner",
 ]

--- a/src/workflow_engine/core/migration/__init__.py
+++ b/src/workflow_engine/core/migration/__init__.py
@@ -1,0 +1,22 @@
+# workflow_engine/core/migration/__init__.py
+"""Node migration system for handling version upgrades."""
+
+from .exceptions import (
+    MigrationError,
+    MigrationNotFoundError,
+    MigrationValidationError,
+)
+from .migration import Migration
+from .registry import MigrationRegistry, migration_registry
+from .runner import MigrationRunner, migration_runner
+
+__all__ = [
+    "Migration",
+    "MigrationError",
+    "MigrationNotFoundError",
+    "MigrationRegistry",
+    "MigrationRunner",
+    "MigrationValidationError",
+    "migration_registry",
+    "migration_runner",
+]

--- a/src/workflow_engine/core/migration/exceptions.py
+++ b/src/workflow_engine/core/migration/exceptions.py
@@ -1,0 +1,34 @@
+# workflow_engine/core/migration/exceptions.py
+"""Migration-related exceptions."""
+
+
+class MigrationError(Exception):
+    """Base exception for migration errors."""
+
+    pass
+
+
+class MigrationNotFoundError(MigrationError):
+    """Raised when no migration path exists between versions."""
+
+    def __init__(self, node_type: str, from_version: str, to_version: str):
+        self.node_type = node_type
+        self.from_version = from_version
+        self.to_version = to_version
+        super().__init__(
+            f"No migration path found for {node_type} "
+            f"from version {from_version} to {to_version}"
+        )
+
+
+class MigrationValidationError(MigrationError):
+    """Raised when migration validation fails."""
+
+    pass
+
+
+__all__ = [
+    "MigrationError",
+    "MigrationNotFoundError",
+    "MigrationValidationError",
+]

--- a/src/workflow_engine/core/migration/migration.py
+++ b/src/workflow_engine/core/migration/migration.py
@@ -1,0 +1,81 @@
+# workflow_engine/core/migration/migration.py
+"""Base class for node migrations."""
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+
+class Migration(ABC):
+    """
+    Base class for node migrations.
+
+    A migration transforms serialized node data from one version to another.
+    Migrations operate on raw dict data BEFORE Pydantic validation, allowing
+    schema changes between versions.
+
+    Example:
+        ```python
+        from workflow_engine.core.migration import Migration, migration_registry
+
+        @migration_registry.register
+        class MyNodeMigration_1_0_0_to_2_0_0(Migration):
+            node_type = "MyNode"
+            from_version = "1.0.0"
+            to_version = "2.0.0"
+
+            def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+                result = dict(data)
+                params = dict(result.get("params", {}))
+                # Rename 'old_field' to 'new_field'
+                params["new_field"] = params.pop("old_field", "default")
+                result["params"] = params
+                return result
+        ```
+    """
+
+    # The node type this migration applies to (e.g., "ConstantString")
+    node_type: ClassVar[str]
+
+    # Source version (the version being migrated FROM)
+    from_version: ClassVar[str]
+
+    # Target version (the version being migrated TO)
+    to_version: ClassVar[str]
+
+    @abstractmethod
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Transform node data from from_version to to_version.
+
+        Args:
+            data: Raw serialized node data with version == from_version.
+                  Contains keys like 'type', 'id', 'version', 'params'.
+
+        Returns:
+            Transformed node data ready for to_version schema.
+            The 'version' field will be updated by the MigrationRunner.
+
+        Note:
+            - The input 'version' field will be from_version
+            - Do NOT modify the 'version' field (handled by runner)
+            - The 'type' and 'id' fields should be preserved
+            - Return a new dict; do not mutate the input
+        """
+        raise NotImplementedError
+
+    def validate(self, data: dict[str, Any]) -> list[str]:
+        """
+        Optionally validate that the data can be migrated.
+
+        Override this method to add pre-migration validation checks.
+
+        Args:
+            data: Raw serialized node data to validate
+
+        Returns:
+            List of validation error messages (empty if valid)
+        """
+        return []
+
+
+__all__ = ["Migration"]

--- a/src/workflow_engine/core/migration/registry.py
+++ b/src/workflow_engine/core/migration/registry.py
@@ -1,0 +1,163 @@
+# workflow_engine/core/migration/registry.py
+"""Registry for node migrations."""
+
+import logging
+from collections import deque
+from typing import Type
+
+from .migration import Migration
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationRegistry:
+    """
+    Registry for node migrations.
+
+    Migrations are indexed by (node_type, from_version) pairs.
+    The registry supports finding migration paths between versions
+    using breadth-first search.
+
+    Example:
+        ```python
+        from workflow_engine.core.migration import Migration, migration_registry
+
+        @migration_registry.register
+        class MyMigration(Migration):
+            node_type = "MyNode"
+            from_version = "1.0.0"
+            to_version = "2.0.0"
+
+            def migrate(self, data):
+                return data
+        ```
+    """
+
+    def __init__(self):
+        # Key: (node_type, from_version), Value: Migration class
+        self._migrations: dict[tuple[str, str], Type[Migration]] = {}
+
+    def register(self, migration_cls: Type[Migration]) -> Type[Migration]:
+        """
+        Register a migration class.
+
+        Can be used as a decorator:
+            @migration_registry.register
+            class MyMigration(Migration):
+                ...
+
+        Args:
+            migration_cls: The Migration subclass to register
+
+        Returns:
+            The migration class (for decorator usage)
+
+        Raises:
+            ValueError: If a migration for this (node_type, from_version) is already registered
+        """
+        key = (migration_cls.node_type, migration_cls.from_version)
+        if key in self._migrations:
+            existing = self._migrations[key]
+            if migration_cls is not existing:
+                raise ValueError(
+                    f"Migration for {migration_cls.node_type} from {migration_cls.from_version} "
+                    f"already registered: {existing.__name__}"
+                )
+        self._migrations[key] = migration_cls
+        logger.debug(
+            "Registered migration %s for %s: %s -> %s",
+            migration_cls.__name__,
+            migration_cls.node_type,
+            migration_cls.from_version,
+            migration_cls.to_version,
+        )
+        return migration_cls
+
+    def get(self, node_type: str, from_version: str) -> Type[Migration] | None:
+        """
+        Get a migration for the given node type and source version.
+
+        Args:
+            node_type: The node type (e.g., "ConstantString")
+            from_version: The source version to migrate from
+
+        Returns:
+            The Migration class, or None if not found
+        """
+        return self._migrations.get((node_type, from_version))
+
+    def get_migration_path(
+        self,
+        node_type: str,
+        from_version: str,
+        to_version: str,
+    ) -> list[Type[Migration]]:
+        """
+        Find the chain of migrations needed to go from from_version to to_version.
+
+        Uses breadth-first search to find the shortest path through the
+        version graph.
+
+        Args:
+            node_type: The node type to migrate
+            from_version: Starting version
+            to_version: Target version
+
+        Returns:
+            Ordered list of Migration classes to apply, or empty list if
+            no path exists or versions are the same.
+        """
+        if from_version == to_version:
+            return []
+
+        # Build adjacency list for this node type
+        adj: dict[str, list[tuple[str, Type[Migration]]]] = {}
+        for (ntype, fv), migration_cls in self._migrations.items():
+            if ntype == node_type:
+                adj.setdefault(fv, []).append(
+                    (migration_cls.to_version, migration_cls)
+                )
+
+        # BFS to find shortest path
+        queue: deque[tuple[str, list[Type[Migration]]]] = deque(
+            [(from_version, [])]
+        )
+        visited = {from_version}
+
+        while queue:
+            current, path = queue.popleft()
+
+            for next_version, migration_cls in adj.get(current, []):
+                new_path = path + [migration_cls]
+
+                if next_version == to_version:
+                    return new_path
+
+                if next_version not in visited:
+                    visited.add(next_version)
+                    queue.append((next_version, new_path))
+
+        return []  # No path found
+
+    def has_migrations_for(self, node_type: str) -> bool:
+        """
+        Check if any migrations are registered for a node type.
+
+        Args:
+            node_type: The node type to check
+
+        Returns:
+            True if at least one migration exists for this node type
+        """
+        return any(ntype == node_type for ntype, _ in self._migrations.keys())
+
+    def clear(self):
+        """Clear all registered migrations. Useful for testing."""
+        self._migrations.clear()
+
+
+# Global singleton registry
+migration_registry = MigrationRegistry()
+
+
+__all__ = ["MigrationRegistry", "migration_registry"]

--- a/src/workflow_engine/core/migration/runner.py
+++ b/src/workflow_engine/core/migration/runner.py
@@ -1,0 +1,145 @@
+# workflow_engine/core/migration/runner.py
+"""Migration runner for applying migrations to node data."""
+
+import logging
+from typing import Any
+
+from .exceptions import MigrationNotFoundError, MigrationValidationError
+from .registry import MigrationRegistry, migration_registry
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationRunner:
+    """
+    Applies migrations to transform node data between versions.
+
+    The runner finds the migration path from the source version to the
+    target version and applies each migration in sequence.
+
+    Example:
+        ```python
+        from workflow_engine.core.migration import migration_runner
+
+        old_data = {
+            "type": "MyNode",
+            "id": "node1",
+            "version": "1.0.0",
+            "params": {"old_field": "value"}
+        }
+
+        new_data = migration_runner.migrate(old_data, target_version="2.0.0")
+        # new_data now has version="2.0.0" and migrated params
+        ```
+    """
+
+    def __init__(self, registry: MigrationRegistry | None = None):
+        """
+        Initialize the migration runner.
+
+        Args:
+            registry: The migration registry to use. Defaults to the
+                      global migration_registry singleton.
+        """
+        self._registry = registry or migration_registry
+
+    def migrate(
+        self,
+        data: dict[str, Any],
+        target_version: str,
+    ) -> dict[str, Any]:
+        """
+        Migrate node data to the target version.
+
+        Args:
+            data: Raw serialized node data containing 'type', 'version', etc.
+            target_version: The version to migrate to
+
+        Returns:
+            Migrated node data with version == target_version
+
+        Raises:
+            MigrationNotFoundError: If no migration path exists
+            MigrationValidationError: If migration validation fails
+        """
+        node_type = data.get("type")
+        current_version = data.get("version")
+
+        if current_version == target_version:
+            return data
+
+        if node_type is None:
+            raise MigrationValidationError("Node data missing 'type' field")
+
+        if current_version is None:
+            raise MigrationValidationError("Node data missing 'version' field")
+
+        # Find migration path
+        migrations = self._registry.get_migration_path(
+            node_type, current_version, target_version
+        )
+
+        if not migrations:
+            raise MigrationNotFoundError(node_type, current_version, target_version)
+
+        logger.debug(
+            "Migrating %s from %s to %s via %d migration(s)",
+            node_type,
+            current_version,
+            target_version,
+            len(migrations),
+        )
+
+        # Apply migrations in sequence
+        result = dict(data)
+        for migration_cls in migrations:
+            migration = migration_cls()
+
+            # Validate before migrating
+            errors = migration.validate(result)
+            if errors:
+                raise MigrationValidationError(
+                    f"Migration {migration_cls.__name__} validation failed: {errors}"
+                )
+
+            # Apply migration
+            logger.debug(
+                "Applying migration %s: %s -> %s",
+                migration_cls.__name__,
+                migration_cls.from_version,
+                migration_cls.to_version,
+            )
+            result = migration.migrate(result)
+            result["version"] = migration_cls.to_version
+
+        return result
+
+    def can_migrate(
+        self,
+        node_type: str,
+        from_version: str,
+        to_version: str,
+    ) -> bool:
+        """
+        Check if a migration path exists.
+
+        Args:
+            node_type: The node type to migrate
+            from_version: Starting version
+            to_version: Target version
+
+        Returns:
+            True if a migration path exists
+        """
+        if from_version == to_version:
+            return True
+        return bool(
+            self._registry.get_migration_path(node_type, from_version, to_version)
+        )
+
+
+# Global singleton runner
+migration_runner = MigrationRunner()
+
+
+__all__ = ["MigrationRunner", "migration_runner"]

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
+    Any,
     Awaitable,
     ClassVar,
     Generic,
@@ -200,7 +201,10 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
             cls = _registry.get(self.type)
             if cls is None:
                 raise ValueError(f'Node type "{self.type}" is not registered')
-            return cls.model_validate(self.model_dump())
+            data = self.model_dump()
+            # Attempt migration before dispatching to subclass
+            data = _migrate_node_data(data, cls)
+            return cls.model_validate(data)
         if self.__class__ is Node:
             warnings.warn(
                 f"Node validation for node {self} could not find a registered subclass to dispatch to."
@@ -265,10 +269,11 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
                 f"Node version {self.version} is newer than the latest version ({type_info.version}) supported by this workflow engine instance."
             )
         elif type_info.version_tuple > self.version_tuple:
+            # Migration was attempted in _to_subclass but no migration path exists.
+            # Issue a warning but allow the node to load (graceful degradation).
             warnings.warn(
                 f"Node version {self.version} is older than the latest version ({type_info.version}) supported by this workflow engine instance, and may need to be migrated."
             )
-            # TODO: a migration system
         return self
 
     # --------------------------------------------------------------------------
@@ -409,6 +414,74 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output_co, Params_co]):
             else:
                 assert isinstance(e, Exception)
                 raise NodeException(self.id) from e
+
+
+def _migrate_node_data(data: dict[str, Any], target_cls: Type["Node"]) -> dict[str, Any]:
+    """
+    Attempt to migrate node data to the target class's version.
+
+    This function is called during node deserialization, before the data
+    is validated by the target class. If migration is needed and a migration
+    path exists, the data is transformed. Otherwise, the original data is
+    returned (graceful degradation - validation warnings will be issued later).
+
+    Args:
+        data: Raw node data dict with 'type', 'version', 'id', 'params', etc.
+        target_cls: The concrete Node subclass to migrate to
+
+    Returns:
+        Migrated data dict, or original data if no migration needed/available
+    """
+    # Skip if target class doesn't have TYPE_INFO (shouldn't happen for concrete classes)
+    if not hasattr(target_cls, "TYPE_INFO"):
+        return data
+
+    current_version = data.get("version", LATEST_SEMANTIC_VERSION)
+
+    # Skip if using "latest" version (will be resolved to current version later)
+    if current_version == LATEST_SEMANTIC_VERSION:
+        return data
+
+    type_info = target_cls.TYPE_INFO
+    target_version = type_info.version
+
+    # Skip if versions match
+    if current_version == target_version:
+        return data
+
+    try:
+        current_tuple = parse_semantic_version(current_version)
+    except ValueError:
+        # Invalid version format, let validation handle it
+        return data
+
+    # Only migrate if current version is older
+    if current_tuple >= type_info.version_tuple:
+        return data
+
+    # Attempt migration
+    # Import here to avoid circular imports
+    from .migration import MigrationNotFoundError, migration_runner
+
+    try:
+        migrated_data = migration_runner.migrate(data, target_version)
+        logger.debug(
+            "Migrated node %s from version %s to %s",
+            data.get("id"),
+            current_version,
+            target_version,
+        )
+        return migrated_data
+    except MigrationNotFoundError:
+        # No migration path available - return original data
+        # Warning will be issued in validate_version
+        logger.debug(
+            "No migration path found for node %s from version %s to %s",
+            data.get("id"),
+            current_version,
+            target_version,
+        )
+        return data
 
 
 class NodeRegistry:

--- a/tests/test_migration_registry.py
+++ b/tests/test_migration_registry.py
@@ -1,0 +1,202 @@
+# tests/test_migration_registry.py
+"""Tests for MigrationRegistry."""
+
+from typing import Any
+
+import pytest
+
+from workflow_engine.core.migration import Migration, MigrationRegistry
+
+
+class MockMigration_1_0_0_to_2_0_0(Migration):
+    """Test migration from 1.0.0 to 2.0.0."""
+
+    node_type = "TestNode"
+    from_version = "1.0.0"
+    to_version = "2.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        return dict(data)
+
+
+class MockMigration_2_0_0_to_3_0_0(Migration):
+    """Test migration from 2.0.0 to 3.0.0."""
+
+    node_type = "TestNode"
+    from_version = "2.0.0"
+    to_version = "3.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        return dict(data)
+
+
+class MockMigration_1_0_0_to_3_0_0(Migration):
+    """Direct migration from 1.0.0 to 3.0.0 (shortcut)."""
+
+    node_type = "TestNode"
+    from_version = "1.0.0"
+    to_version = "3.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        return dict(data)
+
+
+class OtherNodeMigration(Migration):
+    """Migration for a different node type."""
+
+    node_type = "OtherNode"
+    from_version = "1.0.0"
+    to_version = "2.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        return dict(data)
+
+
+class TestMigrationRegistry:
+    """Tests for MigrationRegistry."""
+
+    @pytest.fixture
+    def registry(self) -> MigrationRegistry:
+        """Create a fresh registry for each test."""
+        return MigrationRegistry()
+
+    @pytest.mark.unit
+    def test_register_migration(self, registry: MigrationRegistry):
+        """Test basic migration registration."""
+        result = registry.register(MockMigration_1_0_0_to_2_0_0)
+
+        # Should return the class for decorator usage
+        assert result is MockMigration_1_0_0_to_2_0_0
+
+        # Should be retrievable
+        migration = registry.get("TestNode", "1.0.0")
+        assert migration is MockMigration_1_0_0_to_2_0_0
+
+    @pytest.mark.unit
+    def test_register_duplicate_raises_error(self, registry: MigrationRegistry):
+        """Test that registering duplicate migration raises error."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+
+        # Create a different class with same node_type and from_version
+        class DuplicateMigration(Migration):
+            node_type = "TestNode"
+            from_version = "1.0.0"
+            to_version = "2.5.0"
+
+            def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+                return data
+
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(DuplicateMigration)
+
+    @pytest.mark.unit
+    def test_register_same_class_twice_is_ok(self, registry: MigrationRegistry):
+        """Test that registering the same class twice is allowed."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+        registry.register(MockMigration_1_0_0_to_2_0_0)  # Should not raise
+
+    @pytest.mark.unit
+    def test_get_unregistered_returns_none(self, registry: MigrationRegistry):
+        """Test that getting unregistered migration returns None."""
+        result = registry.get("NonExistent", "1.0.0")
+        assert result is None
+
+    @pytest.mark.unit
+    def test_get_migration_path_same_version(self, registry: MigrationRegistry):
+        """Test that same version returns empty path."""
+        path = registry.get_migration_path("TestNode", "1.0.0", "1.0.0")
+        assert path == []
+
+    @pytest.mark.unit
+    def test_get_migration_path_single_step(self, registry: MigrationRegistry):
+        """Test finding a single-step migration path."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+
+        path = registry.get_migration_path("TestNode", "1.0.0", "2.0.0")
+        assert len(path) == 1
+        assert path[0] is MockMigration_1_0_0_to_2_0_0
+
+    @pytest.mark.unit
+    def test_get_migration_path_multi_step(self, registry: MigrationRegistry):
+        """Test finding a multi-step migration path."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+        registry.register(MockMigration_2_0_0_to_3_0_0)
+
+        path = registry.get_migration_path("TestNode", "1.0.0", "3.0.0")
+        assert len(path) == 2
+        assert path[0] is MockMigration_1_0_0_to_2_0_0
+        assert path[1] is MockMigration_2_0_0_to_3_0_0
+
+    @pytest.mark.unit
+    def test_get_migration_path_finds_available_route(self, registry: MigrationRegistry):
+        """Test that BFS finds available migration route."""
+        # Register multi-step path
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+        registry.register(MockMigration_2_0_0_to_3_0_0)
+
+        path = registry.get_migration_path("TestNode", "1.0.0", "3.0.0")
+        # Should find the 2-step path
+        assert len(path) == 2
+        assert path[0] is MockMigration_1_0_0_to_2_0_0
+        assert path[1] is MockMigration_2_0_0_to_3_0_0
+
+    @pytest.mark.unit
+    def test_get_migration_path_no_path_exists(self, registry: MigrationRegistry):
+        """Test that missing path returns empty list."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+
+        # No path from 2.0.0 to 4.0.0
+        path = registry.get_migration_path("TestNode", "2.0.0", "4.0.0")
+        assert path == []
+
+    @pytest.mark.unit
+    def test_get_migration_path_different_node_types(self, registry: MigrationRegistry):
+        """Test that paths don't cross node types."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+        registry.register(OtherNodeMigration)
+
+        # TestNode migrations shouldn't work for OtherNode
+        path = registry.get_migration_path("OtherNode", "1.0.0", "2.0.0")
+        assert len(path) == 1
+        assert path[0] is OtherNodeMigration
+
+        # And vice versa
+        path = registry.get_migration_path("TestNode", "1.0.0", "2.0.0")
+        assert len(path) == 1
+        assert path[0] is MockMigration_1_0_0_to_2_0_0
+
+    @pytest.mark.unit
+    def test_has_migrations_for(self, registry: MigrationRegistry):
+        """Test checking if migrations exist for a node type."""
+        assert not registry.has_migrations_for("TestNode")
+
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+
+        assert registry.has_migrations_for("TestNode")
+        assert not registry.has_migrations_for("OtherNode")
+
+    @pytest.mark.unit
+    def test_clear(self, registry: MigrationRegistry):
+        """Test clearing all migrations."""
+        registry.register(MockMigration_1_0_0_to_2_0_0)
+        assert registry.has_migrations_for("TestNode")
+
+        registry.clear()
+
+        assert not registry.has_migrations_for("TestNode")
+        assert registry.get("TestNode", "1.0.0") is None
+
+    @pytest.mark.unit
+    def test_decorator_usage(self, registry: MigrationRegistry):
+        """Test using register as a decorator."""
+
+        @registry.register
+        class DecoratedMigration(Migration):
+            node_type = "DecoratedNode"
+            from_version = "1.0.0"
+            to_version = "2.0.0"
+
+            def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+                return data
+
+        assert registry.get("DecoratedNode", "1.0.0") is DecoratedMigration

--- a/tests/test_migration_runner.py
+++ b/tests/test_migration_runner.py
@@ -1,0 +1,261 @@
+# tests/test_migration_runner.py
+"""Tests for MigrationRunner."""
+
+from typing import Any
+
+import pytest
+
+from workflow_engine.core.migration import (
+    Migration,
+    MigrationNotFoundError,
+    MigrationRegistry,
+    MigrationRunner,
+    MigrationValidationError,
+)
+
+
+class ParamRenameMigration(Migration):
+    """Migration that renames a parameter."""
+
+    node_type = "TestNode"
+    from_version = "1.0.0"
+    to_version = "2.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        result = dict(data)
+        params = dict(result.get("params", {}))
+        # Rename 'old_field' to 'new_field'
+        if "old_field" in params:
+            params["new_field"] = params.pop("old_field")
+        result["params"] = params
+        return result
+
+
+class AddDefaultFieldMigration(Migration):
+    """Migration that adds a default field."""
+
+    node_type = "TestNode"
+    from_version = "2.0.0"
+    to_version = "3.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        result = dict(data)
+        params = dict(result.get("params", {}))
+        # Add new required field with default
+        if "extra_field" not in params:
+            params["extra_field"] = "default_value"
+        result["params"] = params
+        return result
+
+
+class ValidationMigration(Migration):
+    """Migration with validation."""
+
+    node_type = "ValidatedNode"
+    from_version = "1.0.0"
+    to_version = "2.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        return dict(data)
+
+    def validate(self, data: dict[str, Any]) -> list[str]:
+        errors = []
+        if "required_field" not in data.get("params", {}):
+            errors.append("Missing required_field in params")
+        return errors
+
+
+class TestMigrationRunner:
+    """Tests for MigrationRunner."""
+
+    @pytest.fixture
+    def registry(self) -> MigrationRegistry:
+        """Create a fresh registry for each test."""
+        return MigrationRegistry()
+
+    @pytest.fixture
+    def runner(self, registry: MigrationRegistry) -> MigrationRunner:
+        """Create a runner with the test registry."""
+        return MigrationRunner(registry)
+
+    @pytest.mark.unit
+    def test_migrate_same_version_returns_data(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that migrating to same version returns original data."""
+        data = {
+            "type": "TestNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"field": "value"},
+        }
+
+        result = runner.migrate(data, "1.0.0")
+        assert result == data
+
+    @pytest.mark.unit
+    def test_migrate_single_step(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test single-step migration."""
+        registry.register(ParamRenameMigration)
+
+        data = {
+            "type": "TestNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"old_field": "value"},
+        }
+
+        result = runner.migrate(data, "2.0.0")
+
+        assert result["version"] == "2.0.0"
+        assert result["params"]["new_field"] == "value"
+        assert "old_field" not in result["params"]
+
+    @pytest.mark.unit
+    def test_migrate_multi_step(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test multi-step migration chain."""
+        registry.register(ParamRenameMigration)
+        registry.register(AddDefaultFieldMigration)
+
+        data = {
+            "type": "TestNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"old_field": "value"},
+        }
+
+        result = runner.migrate(data, "3.0.0")
+
+        assert result["version"] == "3.0.0"
+        assert result["params"]["new_field"] == "value"
+        assert result["params"]["extra_field"] == "default_value"
+        assert "old_field" not in result["params"]
+
+    @pytest.mark.unit
+    def test_migrate_no_path_raises_error(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that missing migration path raises error."""
+        data = {
+            "type": "TestNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {},
+        }
+
+        with pytest.raises(MigrationNotFoundError) as exc_info:
+            runner.migrate(data, "2.0.0")
+
+        assert exc_info.value.node_type == "TestNode"
+        assert exc_info.value.from_version == "1.0.0"
+        assert exc_info.value.to_version == "2.0.0"
+
+    @pytest.mark.unit
+    def test_migrate_missing_type_raises_error(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that missing type field raises error."""
+        data = {
+            "id": "test",
+            "version": "1.0.0",
+            "params": {},
+        }
+
+        with pytest.raises(MigrationValidationError, match="missing 'type' field"):
+            runner.migrate(data, "2.0.0")
+
+    @pytest.mark.unit
+    def test_migrate_missing_version_raises_error(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that missing version field raises error."""
+        data = {
+            "type": "TestNode",
+            "id": "test",
+            "params": {},
+        }
+
+        with pytest.raises(MigrationValidationError, match="missing 'version' field"):
+            runner.migrate(data, "2.0.0")
+
+    @pytest.mark.unit
+    def test_migrate_validation_failure(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that validation errors are raised."""
+        registry.register(ValidationMigration)
+
+        data = {
+            "type": "ValidatedNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {},  # Missing required_field
+        }
+
+        with pytest.raises(MigrationValidationError, match="validation failed"):
+            runner.migrate(data, "2.0.0")
+
+    @pytest.mark.unit
+    def test_migrate_validation_passes(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that valid data passes validation."""
+        registry.register(ValidationMigration)
+
+        data = {
+            "type": "ValidatedNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"required_field": "present"},
+        }
+
+        result = runner.migrate(data, "2.0.0")
+        assert result["version"] == "2.0.0"
+
+    @pytest.mark.unit
+    def test_can_migrate_same_version(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test can_migrate returns True for same version."""
+        assert runner.can_migrate("TestNode", "1.0.0", "1.0.0")
+
+    @pytest.mark.unit
+    def test_can_migrate_with_path(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test can_migrate returns True when path exists."""
+        registry.register(ParamRenameMigration)
+
+        assert runner.can_migrate("TestNode", "1.0.0", "2.0.0")
+
+    @pytest.mark.unit
+    def test_can_migrate_without_path(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test can_migrate returns False when no path exists."""
+        assert not runner.can_migrate("TestNode", "1.0.0", "2.0.0")
+
+    @pytest.mark.unit
+    def test_migrate_preserves_extra_fields(
+        self, runner: MigrationRunner, registry: MigrationRegistry
+    ):
+        """Test that extra fields are preserved during migration."""
+        registry.register(ParamRenameMigration)
+
+        data = {
+            "type": "TestNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"old_field": "value"},
+            "position": {"x": 100, "y": 200},  # Extra field
+            "metadata": {"author": "test"},  # Another extra field
+        }
+
+        result = runner.migrate(data, "2.0.0")
+
+        assert result["position"] == {"x": 100, "y": 200}
+        assert result["metadata"] == {"author": "test"}

--- a/tests/test_node_migration.py
+++ b/tests/test_node_migration.py
@@ -1,0 +1,342 @@
+# tests/test_node_migration.py
+"""Integration tests for node migration during deserialization."""
+
+import warnings
+from typing import Any, ClassVar, Literal, Type
+
+import pytest
+
+from workflow_engine import StringValue
+from workflow_engine.core import Empty, Node, NodeTypeInfo, Params
+from workflow_engine.core.migration import Migration, migration_registry
+from workflow_engine.core.values import Data
+
+
+# Test fixtures: a node type with migrations
+
+
+class MigratableParams(Params):
+    """Parameters for migratable test node."""
+
+    value: StringValue
+
+
+class MigratableOutput(Data):
+    """Output for migratable test node."""
+
+    result: StringValue
+
+
+class MigratableNode(Node[Empty, MigratableOutput, MigratableParams]):
+    """A node type used for testing migrations."""
+
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        name="MigratableNode",
+        display_name="Migratable Node",
+        description="A test node for migration testing",
+        version="2.0.0",  # Current version
+        parameter_type=MigratableParams,
+    )
+
+    type: Literal["MigratableNode"] = "MigratableNode"
+
+    @property
+    def input_type(self) -> Type[Empty]:
+        return Empty
+
+    @property
+    def output_type(self) -> Type[MigratableOutput]:
+        return MigratableOutput
+
+    async def run(self, context: Any, input: Empty) -> MigratableOutput:
+        return MigratableOutput(result=self.params.value)
+
+
+class MigratableNodeMigration_1_0_0_to_2_0_0(Migration):
+    """Migration from 1.0.0 to 2.0.0 for MigratableNode."""
+
+    node_type = "MigratableNode"
+    from_version = "1.0.0"
+    to_version = "2.0.0"
+
+    def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+        result = dict(data)
+        params = dict(result.get("params", {}))
+        # In v1, the field was called 'text', in v2 it's 'value'
+        if "text" in params:
+            params["value"] = params.pop("text")
+        result["params"] = params
+        return result
+
+
+@pytest.fixture(autouse=True)
+def clean_migration_registry():
+    """Clean the migration registry before and after each test."""
+    # Store original migrations
+    original_migrations = dict(migration_registry._migrations)
+
+    yield
+
+    # Restore original state
+    migration_registry._migrations = original_migrations
+
+
+class TestNodeMigration:
+    """Integration tests for automatic node migration."""
+
+    @pytest.mark.unit
+    def test_load_current_version_no_migration(self):
+        """Test that loading current version doesn't trigger migration."""
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "2.0.0",
+            "params": {"value": "hello"},
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            node = Node.model_validate(data)
+
+            # Should not warn
+            assert len(w) == 0
+
+        assert isinstance(node, MigratableNode)
+        assert node.version == "2.0.0"
+        assert node.params.value.root == "hello"
+
+    @pytest.mark.unit
+    def test_load_old_version_with_migration(self):
+        """Test that old version is automatically migrated."""
+        # Register the migration
+        migration_registry.register(MigratableNodeMigration_1_0_0_to_2_0_0)
+
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"text": "hello"},  # Old field name
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            node = Node.model_validate(data)
+
+            # Should not warn since migration was successful
+            assert len(w) == 0
+
+        assert isinstance(node, MigratableNode)
+        assert node.version == "2.0.0"  # Migrated to current version
+        assert node.params.value.root == "hello"  # Field renamed
+
+    @pytest.mark.unit
+    def test_load_old_version_without_migration_warns(self):
+        """Test that old version without migration issues warning."""
+        # Don't register any migration
+
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "1.5.0",  # Some old version with no migration
+            "params": {"value": "hello"},
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            node = Node.model_validate(data)
+
+            # Should have at least one warning about old version
+            version_warnings = [
+                warning
+                for warning in w
+                if "1.5.0 is older than" in str(warning.message)
+            ]
+            assert len(version_warnings) >= 1
+            assert "may need to be migrated" in str(version_warnings[0].message)
+
+        assert isinstance(node, MigratableNode)
+        assert node.version == "1.5.0"  # Version unchanged (no migration)
+
+    @pytest.mark.unit
+    def test_migration_via_workflow_deserialization(self):
+        """Test that migration works when loading workflow from JSON."""
+        from workflow_engine import Workflow
+
+        # Register the migration
+        migration_registry.register(MigratableNodeMigration_1_0_0_to_2_0_0)
+
+        workflow_data = {
+            "nodes": [
+                {
+                    "type": "MigratableNode",
+                    "id": "old_node",
+                    "version": "1.0.0",
+                    "params": {"text": "old_value"},
+                }
+            ],
+            "edges": [],
+            "input_edges": [],
+            "output_edges": [
+                {
+                    "source_id": "old_node",
+                    "source_key": "result",
+                    "output_key": "output",
+                }
+            ],
+        }
+
+        workflow = Workflow.model_validate(workflow_data)
+
+        # Node should be migrated
+        node = workflow.nodes[0]
+        assert isinstance(node, MigratableNode)
+        assert node.version == "2.0.0"
+        assert node.params.value.root == "old_value"
+
+    @pytest.mark.unit
+    def test_chained_migration(self):
+        """Test that multi-step migrations work."""
+
+        # Define intermediate migration
+        class Migration_1_5_0_to_2_0_0(Migration):
+            node_type = "MigratableNode"
+            from_version = "1.5.0"
+            to_version = "2.0.0"
+
+            def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+                result = dict(data)
+                params = dict(result.get("params", {}))
+                # In 1.5.0, field was 'content', in 2.0.0 it's 'value'
+                if "content" in params:
+                    params["value"] = params.pop("content")
+                result["params"] = params
+                return result
+
+        class Migration_1_0_0_to_1_5_0(Migration):
+            node_type = "MigratableNode"
+            from_version = "1.0.0"
+            to_version = "1.5.0"
+
+            def migrate(self, data: dict[str, Any]) -> dict[str, Any]:
+                result = dict(data)
+                params = dict(result.get("params", {}))
+                # In 1.0.0, field was 'text', in 1.5.0 it's 'content'
+                if "text" in params:
+                    params["content"] = params.pop("text")
+                result["params"] = params
+                return result
+
+        migration_registry.register(Migration_1_0_0_to_1_5_0)
+        migration_registry.register(Migration_1_5_0_to_2_0_0)
+
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"text": "hello"},
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            node = Node.model_validate(data)
+            assert len(w) == 0
+
+        assert node.version == "2.0.0"
+        assert node.params.value.root == "hello"
+
+    @pytest.mark.unit
+    def test_migration_preserves_extra_fields(self):
+        """Test that extra fields like position are preserved during migration."""
+        migration_registry.register(MigratableNodeMigration_1_0_0_to_2_0_0)
+
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"text": "hello"},
+            "position": {"x": 100, "y": 200},
+        }
+
+        node = Node.model_validate(data)
+
+        # Extra field should be preserved
+        dumped = node.model_dump()
+        assert dumped["position"] == {"x": 100, "y": 200}
+
+    @pytest.mark.unit
+    def test_direct_class_validation_requires_current_schema(self):
+        """Test that calling concrete class directly requires current version schema.
+
+        Migration only works when deserializing via Node.model_validate(), not
+        when calling the concrete class directly. This is by design - direct
+        class validation bypasses the dispatch mechanism where migration occurs.
+
+        Users should use Node.model_validate() for loading workflows with
+        potentially old node versions.
+        """
+        migration_registry.register(MigratableNodeMigration_1_0_0_to_2_0_0)
+
+        # Old version data with old schema
+        old_data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "1.0.0",
+            "params": {"text": "hello"},  # Old field name
+        }
+
+        # Direct validation fails because it doesn't go through migration
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            MigratableNode.model_validate(old_data)
+
+        # But Node.model_validate works with migration
+        node = Node.model_validate(old_data)
+        assert node.version == "2.0.0"
+        assert node.params.value.root == "hello"
+
+        # Direct validation works with current schema
+        current_data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "2.0.0",
+            "params": {"value": "hello"},  # Current field name
+        }
+        node = MigratableNode.model_validate(current_data)
+        assert node.version == "2.0.0"
+
+
+class TestMigrationEdgeCases:
+    """Test edge cases in migration."""
+
+    @pytest.mark.unit
+    def test_latest_version_not_migrated(self):
+        """Test that 'latest' version is not migrated but resolved."""
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "latest",
+            "params": {"value": "hello"},
+        }
+
+        node = Node.model_validate(data)
+
+        # Should resolve to current version
+        assert node.version == "2.0.0"
+
+    @pytest.mark.unit
+    def test_newer_version_raises_error(self):
+        """Test that newer version than current raises error."""
+        from pydantic import ValidationError
+
+        data = {
+            "type": "MigratableNode",
+            "id": "test",
+            "version": "3.0.0",  # Newer than current 2.0.0
+            "params": {"value": "hello"},
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            Node.model_validate(data)
+
+        assert "newer than the latest version" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Implements a migration system that allows node implementations to evolve while maintaining backward compatibility with existing serialized workflows. Closes #31.

- **Automatic migration during deserialization** - Old workflows automatically upgrade when loaded via `Node.model_validate()`
- **Chained migrations** - BFS path-finding allows v1→v2→v3 migration chains
- **Graceful degradation** - If no migration exists, a warning is issued but loading continues
- **User-extensible** - Users can register custom migrations with `@migration_registry.register`

## New Files

**Migration module** (`src/workflow_engine/core/migration/`):
- `migration.py` - `Migration` base class for defining version transformations
- `registry.py` - `MigrationRegistry` with path-finding for chained migrations
- `runner.py` - `MigrationRunner` for applying migration chains
- `exceptions.py` - `MigrationError`, `MigrationNotFoundError`, `MigrationValidationError`

**Tests** (34 new tests):
- `tests/test_migration_registry.py` - 13 unit tests
- `tests/test_migration_runner.py` - 12 unit tests
- `tests/test_node_migration.py` - 9 integration tests

## Usage Example

```python
from workflow_engine import Migration, migration_registry

@migration_registry.register
class MyNodeMigration_1_0_0_to_2_0_0(Migration):
    node_type = "MyNode"
    from_version = "1.0.0"
    to_version = "2.0.0"
    
    def migrate(self, data: dict) -> dict:
        result = dict(data)
        params = dict(result.get("params", {}))
        params["new_field"] = params.pop("old_field")
        result["params"] = params
        return result
```

## Test plan

- [x] All 115 tests pass (`uv run pytest`)
- [x] Type checking passes on new source files (`uv run pyright src/workflow_engine/core/migration/`)
- [x] Migration tests cover: single-step, multi-step, graceful degradation, workflow deserialization

🤖 Generated with [Claude Code](https://claude.ai/code)