### PR TITLE
Add optional input and output types to workflows

### DIFF
--- a/examples/addition.json
+++ b/examples/addition.json
@@ -53,14 +53,16 @@
     {
       "input_key": "c",
       "target_id": "a+b+c",
-      "target_key": "b"
+      "target_key": "b",
+      "input_schema": null
     }
   ],
   "output_edges": [
     {
       "source_id": "a+b+c",
       "source_key": "sum",
-      "output_key": "sum"
+      "output_key": "sum",
+      "output_schema": null
     }
   ]
 }

--- a/examples/append.json
+++ b/examples/append.json
@@ -14,19 +14,22 @@
     {
       "input_key": "text",
       "target_id": "append",
-      "target_key": "text"
+      "target_key": "text",
+      "input_schema": null
     },
     {
       "input_key": "file",
       "target_id": "append",
-      "target_key": "file"
+      "target_key": "file",
+      "input_schema": null
     }
   ],
   "output_edges": [
     {
       "source_id": "append",
       "source_key": "file",
-      "output_key": "file"
+      "output_key": "file",
+      "output_schema": null
     }
   ]
 }

--- a/examples/error.json
+++ b/examples/error.json
@@ -30,7 +30,8 @@
     {
       "source_id": "constant",
       "source_key": "value",
-      "output_key": "text"
+      "output_key": "text",
+      "output_schema": null
     }
   ]
 }

--- a/src/workflow_engine/core/edge.py
+++ b/src/workflow_engine/core/edge.py
@@ -2,7 +2,7 @@
 
 from ..utils.immutable import ImmutableBaseModel
 from .node import Node
-from .values import Value, ValueType
+from .values import Value, ValueType, ValueSchema
 
 
 class Edge(ImmutableBaseModel):
@@ -77,6 +77,7 @@ class InputEdge(ImmutableBaseModel):
     input_key: str
     target_id: str
     target_key: str
+    input_schema: ValueSchema | None = None
 
     @classmethod
     def from_node(
@@ -85,11 +86,13 @@ class InputEdge(ImmutableBaseModel):
         input_key: str,
         target: Node,
         target_key: str,
+        input_schema: ValueSchema | None = None,
     ) -> "InputEdge":
         return cls(
             input_key=input_key,
             target_id=target.id,
             target_key=target_key,
+            input_schema=input_schema,
         )
 
     def validate_types(self, input_type: ValueType, target: Node):
@@ -116,6 +119,7 @@ class OutputEdge(ImmutableBaseModel):
     source_id: str
     source_key: str
     output_key: str
+    output_schema: ValueSchema | None = None
 
     @classmethod
     def from_node(
@@ -124,11 +128,13 @@ class OutputEdge(ImmutableBaseModel):
         source: Node,
         source_key: str,
         output_key: str,
+        output_schema: ValueSchema | None = None,
     ) -> "OutputEdge":
         return cls(
             source_id=source.id,
             source_key=source_key,
             output_key=output_key,
+            output_schema=output_schema,
         )
 
     def validate_types(self, source: Node, output_type: ValueType):

--- a/src/workflow_engine/execution/parallel.py
+++ b/src/workflow_engine/execution/parallel.py
@@ -228,11 +228,18 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
                     )
                     running_tasks[task] = node_id
 
-            output = workflow.get_output(node_outputs)
+            output = await workflow.get_output(
+                context=context,
+                node_outputs=node_outputs,
+            )
 
         except Exception as e:
             errors.add(e)
-            partial_output = workflow.get_output(node_outputs, partial=True)
+            partial_output = await workflow.get_output(
+                context=context,
+                node_outputs=node_outputs,
+                partial=True,
+            )
             errors, partial_output = await context.on_workflow_error(
                 workflow=workflow,
                 input=input,
@@ -243,7 +250,11 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
 
         # Check if we collected any errors in CONTINUE mode
         if errors.any():
-            partial_output = workflow.get_output(node_outputs, partial=True)
+            partial_output = await workflow.get_output(
+                context=context,
+                node_outputs=node_outputs,
+                partial=True,
+            )
             errors, partial_output = await context.on_workflow_error(
                 workflow=workflow,
                 input=input,

--- a/src/workflow_engine/execution/topological.py
+++ b/src/workflow_engine/execution/topological.py
@@ -135,10 +135,17 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
                     )
                 )
 
-            output = workflow.get_output(node_outputs)
+            output = await workflow.get_output(
+                context=context,
+                node_outputs=node_outputs,
+            )
         except Exception as e:
             errors.add(e)
-            partial_output = workflow.get_output(node_outputs, partial=True)
+            partial_output = await workflow.get_output(
+                context=context,
+                node_outputs=node_outputs,
+                partial=True,
+            )
             errors, partial_output = await context.on_workflow_error(
                 workflow=workflow,
                 input=input,

--- a/tests/test_workflow_output_casting.py
+++ b/tests/test_workflow_output_casting.py
@@ -1,0 +1,285 @@
+"""Tests for workflow output type casting.
+
+This module tests that workflow outputs are automatically cast to match the
+expected output types, just like node inputs are cast to expected types.
+"""
+
+import pytest
+
+from workflow_engine import (
+    FloatValue,
+    IntegerValue,
+    JSONValue,
+    OutputEdge,
+    SequenceValue,
+    Workflow,
+)
+from workflow_engine.contexts import InMemoryContext
+from workflow_engine.execution.parallel import ParallelExecutionAlgorithm
+from workflow_engine.execution.topological import TopologicalExecutionAlgorithm
+from workflow_engine.files import JSONLinesFileValue
+from workflow_engine.nodes import ConstantIntegerNode, ConstantStringNode
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_basic_output_casting():
+    """Test that IntegerValue is cast to FloatValue in workflow output."""
+    node = ConstantIntegerNode.from_value(id="producer", value=42)
+
+    # Workflow expects FloatValue output, but node produces IntegerValue
+    workflow = Workflow(
+        nodes=[node],
+        edges=[],
+        input_edges=[],
+        output_edges=[
+            OutputEdge(
+                source_id="producer",
+                source_key="value",
+                output_key="result",
+                output_schema=FloatValue.to_value_schema(),
+            )
+        ],
+    )
+
+    context = InMemoryContext()
+    algorithm = TopologicalExecutionAlgorithm()
+
+    errors, output = await algorithm.execute(
+        context=context, workflow=workflow, input={}
+    )
+
+    assert not errors.any()
+    assert "result" in output
+    assert isinstance(output["result"], FloatValue)
+    assert output["result"] == 42.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_multiple_outputs_casting():
+    """Test that multiple outputs are cast correctly in parallel."""
+    int_node = ConstantIntegerNode.from_value(id="int_producer", value=100)
+    str_node = ConstantStringNode.from_value(id="str_producer", value="123")
+
+    workflow = Workflow(
+        nodes=[int_node, str_node],
+        edges=[],
+        input_edges=[],
+        output_edges=[
+            OutputEdge(
+                source_id="int_producer",
+                source_key="value",
+                output_key="int_result",
+                output_schema=FloatValue.to_value_schema(),
+            ),
+            OutputEdge(
+                source_id="str_producer",
+                source_key="value",
+                output_key="str_result",
+                output_schema=IntegerValue.to_value_schema(),
+            ),
+        ],
+    )
+
+    context = InMemoryContext()
+    algorithm = TopologicalExecutionAlgorithm()
+
+    errors, output = await algorithm.execute(
+        context=context, workflow=workflow, input={}
+    )
+
+    assert not errors.any()
+    assert isinstance(output["int_result"], FloatValue)
+    assert output["int_result"] == 100.0
+    assert isinstance(output["str_result"], IntegerValue)
+    assert output["str_result"] == 123
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_partial_mode_skips_missing_outputs():
+    """Test that partial mode skips missing outputs gracefully."""
+    node = ConstantIntegerNode.from_value(id="producer", value=42)
+
+    workflow = Workflow(
+        nodes=[node],
+        edges=[],
+        input_edges=[],
+        output_edges=[
+            OutputEdge(
+                source_id="producer",
+                source_key="value",
+                output_key="result",
+                output_schema=FloatValue.to_value_schema(),
+            )
+        ],
+    )
+
+    context = InMemoryContext()
+
+    # Call get_output with partial=True and empty node_outputs
+    output = await workflow.get_output(
+        context=context,
+        node_outputs={},
+        partial=True,
+    )
+
+    # Should return empty dict, not raise exception
+    assert output == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_parallel_execution_algorithm():
+    """Test that output casting works with ParallelExecutionAlgorithm."""
+    node = ConstantIntegerNode.from_value(id="producer", value=42)
+
+    workflow = Workflow(
+        nodes=[node],
+        edges=[],
+        input_edges=[],
+        output_edges=[
+            OutputEdge(
+                source_id="producer",
+                source_key="value",
+                output_key="result",
+                output_schema=FloatValue.to_value_schema(),
+            )
+        ],
+    )
+
+    context = InMemoryContext()
+    algorithm = ParallelExecutionAlgorithm()
+
+    errors, output = await algorithm.execute(
+        context=context, workflow=workflow, input={}
+    )
+
+    assert not errors.any()
+    assert isinstance(output["result"], FloatValue)
+    assert output["result"] == 42.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_complex_type_sequence_to_jsonlines():
+    """Test casting complex types like SequenceValue[JSONValue] to JSONLinesFileValue."""
+    # Create a sequence of JSON values
+    json_values = [JSONValue({"name": "Alice"}), JSONValue({"name": "Bob"})]
+    sequence = SequenceValue(json_values)
+
+    # Test that the sequence can be cast to JSONLinesFileValue
+    context = InMemoryContext()
+
+    # Verify the cast is possible
+    assert sequence.can_cast_to(JSONLinesFileValue)
+
+    # Perform the cast
+    result = await sequence.cast_to(JSONLinesFileValue, context=context)
+
+    assert isinstance(result, JSONLinesFileValue)
+
+    # Verify the result has a path (may be relative or absolute depending on context)
+    assert result.path is not None
+    assert len(result.path) > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_casting_when_types_match():
+    """Test that no casting occurs when output types already match."""
+    node = ConstantIntegerNode.from_value(id="producer", value=42)
+
+    workflow = Workflow(
+        nodes=[node],
+        edges=[],
+        input_edges=[],
+        output_edges=[
+            OutputEdge(source_id="producer", source_key="value", output_key="result")
+        ],
+    )
+
+    # Output type matches (IntegerValue -> IntegerValue)
+    assert workflow.output_fields["result"] == (IntegerValue, True)
+
+    context = InMemoryContext()
+    algorithm = TopologicalExecutionAlgorithm()
+
+    errors, output = await algorithm.execute(
+        context=context, workflow=workflow, input={}
+    )
+
+    assert not errors.any()
+    assert isinstance(output["result"], IntegerValue)
+    assert output["result"] == 42
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_input_edge_with_schema():
+    """Test that InputEdge can specify a schema different from target node."""
+    from workflow_engine import InputEdge
+    from workflow_engine.nodes import AddNode
+
+    add_node = AddNode(id="add")
+
+    workflow = Workflow(
+        nodes=[add_node],
+        edges=[],
+        input_edges=[
+            InputEdge(
+                input_key="a",
+                target_id="add",
+                target_key="a",
+                input_schema=FloatValue.to_value_schema(),
+            ),
+            InputEdge(
+                input_key="b",
+                target_id="add",
+                target_key="b",
+                input_schema=FloatValue.to_value_schema(),
+            ),
+        ],
+        output_edges=[
+            OutputEdge(source_id="add", source_key="sum", output_key="result")
+        ],
+    )
+
+    # Workflow should expect FloatValue inputs
+    assert workflow.input_fields["a"][0] == FloatValue
+    assert workflow.input_fields["b"][0] == FloatValue
+
+    context = InMemoryContext()
+    algorithm = TopologicalExecutionAlgorithm()
+
+    errors, output = await algorithm.execute(
+        context=context,
+        workflow=workflow,
+        input={"a": FloatValue(10.5), "b": FloatValue(20.3)},
+    )
+
+    assert not errors.any()
+
+
+@pytest.mark.unit
+def test_backward_compatibility_no_schema():
+    """Test that edges without schemas work exactly as before."""
+    node = ConstantIntegerNode.from_value(id="producer", value=42)
+
+    workflow = Workflow(
+        nodes=[node],
+        edges=[],
+        input_edges=[],
+        output_edges=[
+            OutputEdge(
+                source_id="producer",
+                source_key="value",
+                output_key="result",
+                # No output_schema specified
+            )
+        ],
+    )
+
+    # Should infer IntegerValue from node
+    assert workflow.output_fields["result"][0] == IntegerValue


### PR DESCRIPTION
This PR allows the optional configuration of input and output types on workflow nodes. It matches how we've been doing things in AceTeam for a long time -- inputs/outputs with explicit types.

Without this PR, AceTeam workflows have a bug where you can assign a value to a specifically-typed output, but it won't actually get cast to that type since the underlying workflow engine has no idea what the type is.

It is fully backward-compatible since the input/output types are optional.