### PR TITLE
Add generic ModelValue[M] and ExtractionResultValue

### DIFF
--- a/src/workflow_engine/core/values/__init__.py
+++ b/src/workflow_engine/core/values/__init__.py
@@ -8,9 +8,11 @@ from .data import (
     get_data_fields,
     serialize_data_mapping,
 )
+from .extraction import Entity, ExtractionResult, ExtractionResultValue, Relation
 from .file import File, FileValue
 from .json import JSON, JSONValue
 from .mapping import StringMapValue
+from .model import ModelValue
 from .primitives import BooleanValue, FloatValue, IntegerValue, NullValue, StringValue
 from .schema import ValueSchema, ValueSchemaValue, validate_value_schema
 from .sequence import SequenceValue
@@ -24,6 +26,9 @@ __all__ = [
     "DataMapping",
     "DataValue",
     "dump_data_mapping",
+    "Entity",
+    "ExtractionResult",
+    "ExtractionResultValue",
     "File",
     "FileValue",
     "FloatValue",
@@ -32,7 +37,9 @@ __all__ = [
     "IntegerValue",
     "JSON",
     "JSONValue",
+    "ModelValue",
     "NullValue",
+    "Relation",
     "SequenceValue",
     "serialize_data_mapping",
     "StringMapValue",

--- a/src/workflow_engine/core/values/extraction.py
+++ b/src/workflow_engine/core/values/extraction.py
@@ -1,0 +1,46 @@
+# workflow_engine/core/values/extraction.py
+
+from pydantic import BaseModel, Field
+
+from .model import ModelValue
+
+
+class Entity(BaseModel):
+    """An extracted entity from a document."""
+
+    id: str
+    text: str
+    type: str
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class Relation(BaseModel):
+    """A relation between two entities."""
+
+    id: str
+    type: str
+    subject_id: str
+    object_id: str
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ExtractionResult(BaseModel):
+    """Result of an entity/relation extraction from a document."""
+
+    document_id: str
+    chunk_id: str | None = None
+    source_text: str
+    schema_id: str
+    entities: list[Entity] = Field(default_factory=list)
+    relations: list[Relation] = Field(default_factory=list)
+
+
+ExtractionResultValue = ModelValue[ExtractionResult]
+
+
+__all__ = [
+    "Entity",
+    "ExtractionResult",
+    "ExtractionResultValue",
+    "Relation",
+]

--- a/src/workflow_engine/core/values/model.py
+++ b/src/workflow_engine/core/values/model.py
@@ -1,0 +1,85 @@
+# workflow_engine/core/values/model.py
+
+from typing import TYPE_CHECKING, Generic, Type, TypeVar
+
+from pydantic import BaseModel
+
+from .json import JSONValue
+from .value import Caster, Value, get_origin_and_args
+
+if TYPE_CHECKING:
+    from ..context import Context
+
+M = TypeVar("M", bound=BaseModel)
+
+
+class ModelValue(Value[M], Generic[M]):
+    """Value wrapping a Pydantic BaseModel, validated at edge boundaries."""
+
+    pass
+
+
+SourceType = TypeVar("SourceType", bound=Value)
+TargetType = TypeVar("TargetType", bound=Value)
+
+
+@JSONValue.register_generic_cast_to(ModelValue)
+def cast_json_to_model(
+    source_type: Type[JSONValue],
+    target_type: Type[ModelValue],
+) -> Caster[JSONValue, ModelValue] | None:
+    _origin, args = get_origin_and_args(target_type)
+    if not args:
+        # Unparameterized ModelValue — cannot validate without a model class
+        return None
+
+    model_cls = args[0]
+    if not (isinstance(model_cls, type) and issubclass(model_cls, BaseModel)):
+        return None
+
+    def _cast(value: JSONValue, context: "Context") -> ModelValue:
+        validated = model_cls.model_validate(value.root)
+        return target_type(validated)
+
+    return _cast
+
+
+@ModelValue.register_generic_cast_to(ModelValue)
+def cast_model_to_model(
+    source_type: Type[ModelValue],
+    target_type: Type[ModelValue],
+) -> Caster[ModelValue, ModelValue] | None:
+    _source_origin, source_args = get_origin_and_args(source_type)
+    _target_origin, target_args = get_origin_and_args(target_type)
+
+    if not source_args or not target_args:
+        return None
+
+    source_model_cls = source_args[0]
+    target_model_cls = target_args[0]
+
+    if not (isinstance(source_model_cls, type) and issubclass(source_model_cls, BaseModel)):
+        return None
+    if not (isinstance(target_model_cls, type) and issubclass(target_model_cls, BaseModel)):
+        return None
+
+    # Identity shortcut
+    if source_model_cls is target_model_cls:
+
+        def _identity(value: ModelValue, context: "Context") -> ModelValue:
+            return target_type(value.root)
+
+        return _identity
+
+    # Cross-model cast: serialize then validate
+    def _cast(value: ModelValue, context: "Context") -> ModelValue:
+        dumped = source_model_cls.model_validate(value.root).model_dump()
+        validated = target_model_cls.model_validate(dumped)
+        return target_type(validated)
+
+    return _cast
+
+
+__all__ = [
+    "ModelValue",
+]

--- a/tests/test_model_value.py
+++ b/tests/test_model_value.py
@@ -1,0 +1,208 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from workflow_engine.contexts.in_memory import InMemoryContext
+from workflow_engine.core.values import (
+    JSONValue,
+    ModelValue,
+    Value,
+)
+from workflow_engine.core.values.extraction import (
+    Entity,
+    ExtractionResult,
+    ExtractionResultValue,
+    Relation,
+)
+
+
+@pytest.fixture
+def context():
+    return InMemoryContext()
+
+
+# --- Simple test models ---
+
+
+class PersonModel(BaseModel):
+    name: str
+    age: int
+
+
+class EmployeeModel(BaseModel):
+    name: str
+    age: int
+    department: str
+
+
+PersonValue = ModelValue[PersonModel]
+EmployeeValue = ModelValue[EmployeeModel]
+
+
+# --- ModelValue creation ---
+
+
+@pytest.mark.unit
+def test_model_value_creation():
+    person = PersonModel(name="Alice", age=30)
+    val = PersonValue(person)
+    assert val.root == person
+    assert val.root.name == "Alice"
+    assert val.root.age == 30
+    assert isinstance(val, ModelValue)
+    assert isinstance(val, Value)
+
+
+# --- JSONValue -> ModelValue ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_json_to_model_value_cast(context):
+    json_val = JSONValue({"name": "Bob", "age": 25})
+    result = await json_val.cast_to(PersonValue, context=context)
+    assert isinstance(result.root, PersonModel)
+    assert result.root.name == "Bob"
+    assert result.root.age == 25
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_json_to_model_value_cast_invalid(context):
+    json_val = JSONValue({"name": "Bob"})  # missing required 'age'
+    with pytest.raises(ValidationError):
+        await json_val.cast_to(PersonValue, context=context)
+
+
+@pytest.mark.unit
+def test_json_cannot_cast_to_unparameterized_model_value():
+    assert not JSONValue.can_cast_to(ModelValue)
+
+
+# --- ModelValue -> JSONValue ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_model_value_to_json_cast(context):
+    person = PersonModel(name="Carol", age=40)
+    val = PersonValue(person)
+    json_val = await val.cast_to(JSONValue, context=context)
+    assert isinstance(json_val, JSONValue)
+    assert json_val.root == {"name": "Carol", "age": 40}
+
+
+# --- ModelValue -> ModelValue (same type) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_model_value_same_type_cast(context):
+    person = PersonModel(name="Dave", age=35)
+    val = PersonValue(person)
+    result = await val.cast_to(PersonValue, context=context)
+    assert result.root.name == "Dave"
+    assert result.root.age == 35
+
+
+# --- ModelValue[A] -> ModelValue[B] (compatible) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_model_value_cross_model_cast_compatible(context):
+    """EmployeeModel has a superset of PersonModel fields, so Employee -> Person works."""
+    employee = EmployeeModel(name="Eve", age=28, department="Engineering")
+    val = EmployeeValue(employee)
+    result = await val.cast_to(PersonValue, context=context)
+    assert isinstance(result.root, PersonModel)
+    assert result.root.name == "Eve"
+    assert result.root.age == 28
+
+
+# --- ModelValue[A] -> ModelValue[B] (incompatible) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_model_value_cross_model_cast_incompatible(context):
+    """PersonModel -> EmployeeModel fails because 'department' is missing."""
+    person = PersonModel(name="Frank", age=50)
+    val = PersonValue(person)
+    with pytest.raises(ValidationError):
+        await val.cast_to(EmployeeValue, context=context)
+
+
+# --- can_cast_to checks ---
+
+
+@pytest.mark.unit
+def test_can_cast_to_checks():
+    assert JSONValue.can_cast_to(PersonValue)
+    assert PersonValue.can_cast_to(JSONValue)
+    assert PersonValue.can_cast_to(PersonValue)
+    assert PersonValue.can_cast_to(EmployeeValue)  # generic caster exists, validation at runtime
+    assert EmployeeValue.can_cast_to(PersonValue)
+
+
+# --- ExtractionResultValue ---
+
+
+@pytest.mark.unit
+def test_extraction_result_value_creation():
+    result = ExtractionResult(
+        document_id="doc-1",
+        source_text="Alice works at Acme Corp.",
+        schema_id="schema-v1",
+        entities=[
+            Entity(id="e1", text="Alice", type="PERSON", confidence=0.95),
+            Entity(id="e2", text="Acme Corp.", type="ORGANIZATION"),
+        ],
+        relations=[
+            Relation(
+                id="r1",
+                type="WORKS_AT",
+                subject_id="e1",
+                object_id="e2",
+                confidence=0.9,
+            ),
+        ],
+    )
+    val = ExtractionResultValue(result)
+    assert val.root.document_id == "doc-1"
+    assert len(val.root.entities) == 2
+    assert len(val.root.relations) == 1
+    assert val.root.entities[0].confidence == 0.95
+    assert val.root.entities[1].confidence is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extraction_result_value_json_roundtrip(context):
+    result = ExtractionResult(
+        document_id="doc-2",
+        chunk_id="chunk-1",
+        source_text="Bob is CEO of WidgetCo.",
+        schema_id="schema-v2",
+        entities=[
+            Entity(id="e1", text="Bob", type="PERSON"),
+            Entity(id="e2", text="WidgetCo", type="ORGANIZATION"),
+        ],
+        relations=[
+            Relation(id="r1", type="CEO_OF", subject_id="e1", object_id="e2"),
+        ],
+    )
+    val = ExtractionResultValue(result)
+
+    # ModelValue -> JSONValue
+    json_val = await val.cast_to(JSONValue, context=context)
+    assert isinstance(json_val, JSONValue)
+    assert isinstance(json_val.root, dict)
+    assert json_val.root["document_id"] == "doc-2"
+
+    # JSONValue -> ModelValue
+    restored = await json_val.cast_to(ExtractionResultValue, context=context)
+    assert isinstance(restored.root, ExtractionResult)
+    assert restored.root.document_id == "doc-2"
+    assert restored.root.chunk_id == "chunk-1"
+    assert len(restored.root.entities) == 2
+    assert restored.root.relations[0].type == "CEO_OF"


### PR DESCRIPTION
## Summary

- Add `ModelValue[M]`, a generic Value type wrapping any Pydantic BaseModel with schema validation at edge boundaries
- Register casters: `JSONValue → ModelValue[M]` (validates JSON against model schema), `ModelValue[A] → ModelValue[B]` (cross-model cast via serialize-then-validate)
- Add domain models `Entity`, `Relation`, `ExtractionResult` and the type alias `ExtractionResultValue = ModelValue[ExtractionResult]`
- 11 new unit tests covering creation, all cast directions, validation errors, `can_cast_to` checks, and JSON round-trip

Closes #51

## Test plan

- [x] `uv run pytest tests/test_model_value.py -v` — 11 tests pass
- [x] `uv run pytest` — full suite (167 tests), no regressions
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors

## Security review

**Overall: low risk.** Pydantic `model_validate` gates all data entering ModelValue; types resolved statically at registration time; immutability prevents post-creation tampering.

| Severity | Finding |
|----------|---------|
| Medium | `ExtractionResult.source_text` and list fields have no size constraints — could cause memory exhaustion if populated from untrusted input. Consider adding `max_length` if used at system boundary. |
| Low | Cross-model cast via `model_dump()` may silently coerce fields between models with overlapping names but different types. |
| Informational | Extra fields in JSON input silently dropped (default Pydantic v2 behavior). |
| Informational | No code injection vectors — no `pickle`/`eval`/`exec`/unsafe deserialization. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)