### PR TITLE
Bump version to 2.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aceteam-workflow-engine"
-version = "1.2.0rc1"
+version = "2.0.0rc1"
 description = "A powerful workflow orchestration engine for composing complex computational tasks from modular, type-safe nodes"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps package version from `1.2.0rc1` to `2.0.0rc1` for the first v2 release candidate
- Major version bump reflects breaking changes

## Next steps
After merging, create a GitHub Release with tag `v2.0.0rc1` to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)