### PR TITLE
Allow extra fields in schemas

### DIFF
--- a/src/workflow_engine/core/values/schema.py
+++ b/src/workflow_engine/core/values/schema.py
@@ -46,10 +46,8 @@ def merge_defs(
 
 
 class BaseValueSchema(ImmutableBaseModel):
-    # We will only handle fields that Pydantic actually uses.
-    # extra="forbid" offensively validates that we haven't missed any fields.
     model_config: ClassVar[ConfigDict] = ConfigDict(
-        extra="forbid",
+        extra="allow",
         serialize_by_alias=True,
     )
 


### PR DESCRIPTION
This unlocks things like Fields with min/max bounds, or even schemas with non-essential formatting metadata used by frontend components