### PR TITLE
feat(nodes): add titles and descriptions to all node fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,17 @@ class MyNode(Node[MyInput, MyOutput, MyParams]):
         pass
 ```
 
+**Field Titles and Descriptions**: Every field in `Data`, `Params`, and output model classes must have a `title` and `description` via `Field()`. These are surfaced to end users, so write them for a non-technical audience:
+
+- `title`: A short, human-readable label (title case, e.g. `"Error Name"`)
+- `description`: A noun phrase starting with "The", followed by full sentences only if more context is needed (e.g. `"The name of the error to raise."`)
+
+```python
+class MyInput(Data):
+    value: IntegerValue = Field(title="Value", description="The input value.")
+    items: SequenceValue[StringValue] = Field(title="Items", description="The list of items to process.")
+```
+
 **Immutability**: All core objects are frozen Pydantic models. Use `model_copy()` for updates.
 
 **Async Execution**: Node `run()` methods and Context hooks are all async.

--- a/src/workflow_engine/nodes/arithmetic.py
+++ b/src/workflow_engine/nodes/arithmetic.py
@@ -6,6 +6,8 @@ Simple nodes for testing the workflow engine, with limited usefulness otherwise.
 from functools import cached_property
 from typing import ClassVar, Literal
 
+from pydantic import Field
+
 from ..core import (
     Context,
     Data,
@@ -19,12 +21,12 @@ from ..core import (
 
 
 class AddNodeInput(Data):
-    a: FloatValue
-    b: FloatValue
+    a: FloatValue = Field(title="A", description="The first number.")
+    b: FloatValue = Field(title="B", description="The second number.")
 
 
 class SumOutput(Data):
-    sum: FloatValue
+    sum: FloatValue = Field(title="Sum", description="The sum of the two numbers.")
 
 
 class AddNode(Node[AddNodeInput, SumOutput, Empty]):
@@ -50,11 +52,11 @@ class AddNode(Node[AddNodeInput, SumOutput, Empty]):
 
 
 class SumNodeInput(Data):
-    values: SequenceValue[FloatValue]
+    values: SequenceValue[FloatValue] = Field(title="Values", description="The numbers to sum.")
 
 
 class SumNodeOutput(Data):
-    sum: FloatValue
+    sum: FloatValue = Field(title="Sum", description="The sum of all the numbers.")
 
 
 class SumNode(Node[SumNodeInput, SumNodeOutput, Empty]):
@@ -81,11 +83,11 @@ class SumNode(Node[SumNodeInput, SumNodeOutput, Empty]):
 
 
 class IntegerData(Data):
-    value: IntegerValue
+    value: IntegerValue = Field(title="Value", description="The integer value.")
 
 
 class FactorizationData(Data):
-    factors: SequenceValue[IntegerValue]
+    factors: SequenceValue[IntegerValue] = Field(title="Factors", description="The factors of the integer.")
 
 
 class FactorizationNode(Node[IntegerData, FactorizationData, Empty]):

--- a/src/workflow_engine/nodes/conditional.py
+++ b/src/workflow_engine/nodes/conditional.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from typing import ClassVar, Literal, Self
 
 from overrides import override
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from ..core.values import build_data_type, get_data_fields
 
@@ -26,18 +26,18 @@ from ..utils.mappings import mapping_intersection
 
 
 class IfParams(Params):
-    if_true: WorkflowValue
+    if_true: WorkflowValue = Field(title="If True", description="The workflow to run when the condition is true.")
 
 
 class IfElseParams(Params):
-    if_true: WorkflowValue
-    if_false: WorkflowValue
+    if_true: WorkflowValue = Field(title="If True", description="The workflow to run when the condition is true.")
+    if_false: WorkflowValue = Field(title="If False", description="The workflow to run when the condition is false.")
 
 
 class ConditionalInput(Data):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 
-    condition: BooleanValue
+    condition: BooleanValue = Field(title="Condition", description="The condition to evaluate.")
 
 
 class IfNode(Node[ConditionalInput, Empty, IfParams]):

--- a/src/workflow_engine/nodes/constant.py
+++ b/src/workflow_engine/nodes/constant.py
@@ -2,6 +2,8 @@
 from functools import cached_property
 from typing import ClassVar, Literal
 
+from pydantic import Field
+
 from ..core import (
     BooleanValue,
     Context,
@@ -16,7 +18,7 @@ from ..core import (
 
 
 class ConstantBoolean(Params):
-    value: BooleanValue
+    value: BooleanValue = Field(title="Value", description="The constant boolean value.")
 
 
 class ConstantBooleanNode(Node[Empty, ConstantBoolean, ConstantBoolean]):
@@ -43,7 +45,7 @@ class ConstantBooleanNode(Node[Empty, ConstantBoolean, ConstantBoolean]):
 
 
 class ConstantInteger(Params):
-    value: IntegerValue
+    value: IntegerValue = Field(title="Value", description="The constant integer value.")
 
 
 class ConstantIntegerNode(Node[Empty, ConstantInteger, ConstantInteger]):
@@ -70,7 +72,7 @@ class ConstantIntegerNode(Node[Empty, ConstantInteger, ConstantInteger]):
 
 
 class ConstantString(Params):
-    value: StringValue
+    value: StringValue = Field(title="Value", description="The constant string value.")
 
 
 class ConstantStringNode(Node[Empty, ConstantString, ConstantString]):

--- a/src/workflow_engine/nodes/data.py
+++ b/src/workflow_engine/nodes/data.py
@@ -36,11 +36,11 @@ V = TypeVar("V", bound=Value)
 
 
 class SequenceParams(Params):
-    length: IntegerValue
+    length: IntegerValue = Field(title="Length", description="The number of elements in the sequence.")
 
 
 class SequenceData(Data, Generic[V]):
-    sequence: SequenceValue[V]
+    sequence: SequenceValue[V] = Field(title="Sequence", description="The sequence of values.")
 
 
 class GatherSequenceNode(Node[Data, SequenceData, SequenceParams]):
@@ -182,11 +182,11 @@ class ExpandSequenceNode(Node[SequenceData, Data, SequenceParams]):
 
 
 class MappingParams(Params):
-    keys: SequenceValue[StringValue]
+    keys: SequenceValue[StringValue] = Field(title="Keys", description="The keys of the mapping.")
 
 
 class MappingData(Data, Generic[V]):
-    mapping: StringMapValue[V]
+    mapping: StringMapValue[V] = Field(title="Mapping", description="The mapping of keys to values.")
 
 
 class GatherMappingNode(Node[Data, MappingData, MappingParams]):
@@ -313,7 +313,7 @@ class NestedData(Data, Generic[D]):
     A data type that contains a nested data object.
     """
 
-    data: DataValue[D]
+    data: DataValue[D] = Field(title="Data", description="The nested data object.")
 
 
 class GatherDataNode(Node[Data, NestedData, Empty]):

--- a/src/workflow_engine/nodes/error.py
+++ b/src/workflow_engine/nodes/error.py
@@ -3,6 +3,8 @@
 from functools import cached_property
 from typing import ClassVar, Literal
 
+from pydantic import Field
+
 from ..core import (
     Context,
     Data,
@@ -16,11 +18,11 @@ from ..core import (
 
 
 class ErrorInput(Data):
-    info: StringValue
+    info: StringValue = Field(title="Info", description="Additional information about the error.")
 
 
 class ErrorParams(Params):
-    error_name: StringValue
+    error_name: StringValue = Field(title="Error Name", description="The name of the error to raise.")
 
 
 class ErrorNode(Node[ErrorInput, Empty, ErrorParams]):

--- a/src/workflow_engine/nodes/iteration.py
+++ b/src/workflow_engine/nodes/iteration.py
@@ -7,6 +7,7 @@ from functools import cached_property
 from typing import ClassVar, Literal, Self
 
 from overrides import override
+from pydantic import Field
 
 from workflow_engine.core.io import SchemaParams
 
@@ -34,7 +35,7 @@ from .data import (
 
 
 class ForEachParams(Params):
-    workflow: WorkflowValue
+    workflow: WorkflowValue = Field(title="Workflow", description="The workflow to run for each item.")
 
 
 class ForEachNode(Node[SequenceData, SequenceData | Empty, ForEachParams]):

--- a/src/workflow_engine/nodes/text.py
+++ b/src/workflow_engine/nodes/text.py
@@ -3,6 +3,8 @@ import os
 from functools import cached_property
 from typing import ClassVar, Literal, Self
 
+from pydantic import Field
+
 from ..core import (
     Context,
     Data,
@@ -16,16 +18,16 @@ from ..files import TextFileValue
 
 
 class AppendToFileInput(Data):
-    file: TextFileValue
-    text: StringValue
+    file: TextFileValue = Field(title="File", description="The file to append to.")
+    text: StringValue = Field(title="Text", description="The text to append.")
 
 
 class AppendToFileOutput(Data):
-    file: TextFileValue
+    file: TextFileValue = Field(title="File", description="The resulting file with the text appended.")
 
 
 class AppendToFileParams(Params):
-    suffix: StringValue
+    suffix: StringValue = Field(title="Suffix", description="The suffix to add to the output filename.")
 
 
 class AppendToFileNode(Node[AppendToFileInput, AppendToFileOutput, AppendToFileParams]):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -22,6 +22,8 @@ def test_constant_string_node_type_info():
             "properties": {
                 "value": {
                     "$ref": "#/$defs/StringValue",
+                    "title": "Value",
+                    "description": "The constant string value.",
                 },
             },
             "required": ["value"],
@@ -30,6 +32,15 @@ def test_constant_string_node_type_info():
         },
         "version": "0.4.0",
     }
+
+
+@pytest.mark.unit
+def test_constant_string_node_output_schema_has_field_title_and_description():
+    """Field titles and descriptions should appear in the output schema."""
+    node = ConstantStringNode.from_value(id="test_node", value="test")
+    value_prop = node.output_schema.model_dump()["properties"]["value"]
+    assert value_prop["title"] == "Value"
+    assert value_prop["description"] == "The constant string value."
 
 
 @pytest.mark.unit
@@ -58,6 +69,8 @@ def test_constant_string_node_output_schema():
         "properties": {
             "value": {
                 "$ref": "#/$defs/StringValue",
+                "title": "Value",
+                "description": "The constant string value.",
             },
         },
         "required": ["value"],


### PR DESCRIPTION
## Summary

- Added `Field(title=..., description=...)` to every field in all `Data`, `Params`, and output model classes across all built-in nodes
- Descriptions follow a \"The ...\" noun-phrase convention, written for non-technical users
- Added a test verifying that field titles and descriptions appear in the output schema
- Documented the convention in `CLAUDE.md`

## Test plan

- [x] `uv run pytest -m unit` passes
- [x] Review that titles and descriptions read naturally for a non-technical audience

🤖 Generated with [Claude Code](https://claude.com/claude-code)