### PR TITLE
feat(nodes): make AddNode variadic

### DIFF
--- a/src/workflow_engine/nodes/__init__.py
+++ b/src/workflow_engine/nodes/__init__.py
@@ -1,7 +1,6 @@
 # workflow_engine/nodes/__init__.py
 from .arithmetic import (
     AddNode,
-    AddNodeParams,
     FactorizationNode,
     SumNode,
 )
@@ -35,7 +34,6 @@ from .text import (
 
 __all__ = [
     "AddNode",
-    "AddNodeParams",
     "AppendToFileNode",
     "ConditionalInput",
     "ConstantBooleanNode",

--- a/tests/test_addition.py
+++ b/tests/test_addition.py
@@ -4,7 +4,7 @@ from workflow_engine import Edge, IntegerValue, Workflow
 from workflow_engine.contexts import InMemoryContext
 from workflow_engine.core.io import InputNode, OutputNode
 from workflow_engine.execution import TopologicalExecutionAlgorithm
-from workflow_engine.nodes import AddNode, AddNodeParams, ConstantIntegerNode
+from workflow_engine.nodes import AddNode, ConstantIntegerNode
 
 
 @pytest.fixture
@@ -68,7 +68,7 @@ async def test_add_3_arguments():
         ConstantIntegerNode.from_value(id=f"const_{i}", value=(i + 1) * 10)
         for i in range(3)
     ]
-    add = AddNode(id="add", params=AddNodeParams(num_arguments=IntegerValue(3)))
+    add = AddNode.with_arity(id="add", arity=3)
     output_node = OutputNode.from_fields(sum=IntegerValue)
 
     workflow = Workflow(
@@ -105,7 +105,7 @@ async def test_add_30_arguments():
         ConstantIntegerNode.from_value(id=f"const_{i}", value=i + 1)
         for i in range(n)
     ]
-    add = AddNode(id="add", params=AddNodeParams(num_arguments=IntegerValue(n)))
+    add = AddNode.with_arity(id="add", arity=n)
     output_node = OutputNode.from_fields(sum=IntegerValue)
 
     workflow = Workflow(
@@ -129,7 +129,7 @@ async def test_add_30_arguments():
 
 def test_add_1000_arguments_field_names():
     """Spot-check field names for a 1000-argument AddNode without executing it."""
-    add = AddNode(id="add", params=AddNodeParams(num_arguments=IntegerValue(1000)))
+    add = AddNode.with_arity(id="add", arity=1000)
     fields = add.input_type.model_fields
 
     assert len(fields) == 1000


### PR DESCRIPTION
## Summary

- Replaces the fixed two-input `AddNode` with a variadic version accepting ≥2 inputs via a `num_arguments` parameter (default: 2)
- Input fields are named using an infinite alphabetic sequence: `a`, `b`, ..., `z`, `aa`, `ab`, ..., `all`, ...
- Adds `AddNode.with_arity(id, arity)` factory classmethod as the ergonomic API for higher arities
- Backwards compatible: nodes with no `params` default to `num_arguments=2` (same as before), with a migration registered for v0.4.0 → v1.0.0

## Test plan

- [x] Existing tests pass unchanged (default arity=2 still uses fields `a` and `b`)
- [x] 3-argument execution test (`a`, `b`, `c`)
- [x] 30-argument execution test (verifies boundary between 1- and 2-letter names)
- [x] 1000-argument field name spot-checks (boundaries at `z`/`aa`, `zz`/`aaa`, and `all` at index 999)

🤖 Generated with [Claude Code](https://claude.com/claude-code)