### PR TITLE
fix(schema): fix pre-existing pyright errors in BaseValueSchema and constrained builders

### DIFF
--- a/tests/test_value_registry.py
+++ b/tests/test_value_registry.py
@@ -425,8 +425,8 @@ class TestValueRegistryLoadValue:
         registry = ValueRegistry.builder(lazy=True)
         registry.register_value_class(SampleValueA)
 
-        schema = IntegerValueSchema(
-            **{"type": "integer", "x-value-type": "SampleValueA"}
+        schema = IntegerValueSchema.model_validate(
+            {"type": "integer", "x-value-type": "SampleValueA"}
         )
         loaded_value = registry.load_value(schema)
 
@@ -440,8 +440,8 @@ class TestValueRegistryLoadValue:
         registry.register_value_class(SampleValueA)
         registry.register_value_class(SampleValueB)
 
-        schema = IntegerValueSchema(
-            **{
+        schema = IntegerValueSchema.model_validate(
+            {
                 "type": "integer",
                 "x-value-type": "SampleValueA",
                 "title": "SampleValueB",

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12, <4.0"
 
 [[package]]
 name = "aceteam-workflow-engine"
-version = "2.0.0rc3"
+version = "2.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "dotenv" },


### PR DESCRIPTION
## Summary

Fixes 22 pre-existing pyright errors introduced in #76 (`feat(values): constrained Value subclasses, x-value-type field, and $defs safety`).

Two root causes:

- **`BaseValueSchema.value_type` alias**: The field used `validation_alias="x-value-type"` + `serialization_alias="x-value-type"`, but pyright's Pydantic plugin can't handle non-identifier aliases and misreported `value_type` as a required parameter. Fixed by making it a plain field and doing the `x-value-type` ↔ `value_type` translation manually in the already-existing `model_validator` and `model_serializer`.

- **TypeVar in function body**: `_build_constrained_sequence_cls` and `_build_constrained_map_cls` created a `TypeVar` inside the function body and used it as a generic parameter in `type()` calls. Pyright doesn't support TypeVars defined in function scope as generic parameters. Fixed by moving `_T_item` to module scope and adding `# type: ignore` on the dynamic `type()` lines (which pyright can't statically analyze by design).

Also updates two tests that passed `x-value-type` via `**{...}` kwargs (invalid Python identifier) to use `model_validate()` instead.

## Test plan

- [ ] `uv run pyright` reports 0 errors
- [ ] `uv run pytest` — 413 passed, 1 xfailed
- [ ] `uv run ruff check .` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)