### PR TITLE
docs: document release process and fix uv.lock drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,26 @@ if registry.has_name("foo"):  # Ctrl+Click jumps to has_name()
 - Protocol implementations (context managers, iterators)
 - Pydantic model internals (`__init_subclass__`, `model_validator`)
 
+## Release Process
+
+To cut a new release:
+
+1. **Update `CHANGELOG.md`** — study the commits since the last release tag (`git log <last-tag>..HEAD`), then add a new section at the top (after the header) with the new version, date, and a human-readable summary of what changed. Group entries under `### Added`, `### Changed`, and/or `### Fixed` as appropriate. Follow the existing format.
+
+2. **Run the release script** — must be on a clean, up-to-date `main` branch. The script bumps the version in `pyproject.toml` and `src/workflow_engine/__init__.py`, then runs the full check suite (tests, ruff check, ruff format, pyright) before committing, tagging, pushing, and creating a GitHub release:
+
+```bash
+./release.sh --rc      # bump release candidate: 2.0.0rc4 -> 2.0.0rc5
+./release.sh           # bump patch: 2.0.0 -> 2.0.1
+./release.sh --minor   # bump minor: 2.0.0 -> 2.1.0
+./release.sh --major   # bump major: 2.0.0 -> 3.0.0
+./release.sh 2.0.0     # explicit version
+```
+
+The script prompts for confirmation before making any changes.
+
+3. **PyPI publish** — triggered automatically by GitHub Actions when the tag is pushed. For a manual deploy (emergency or CI unavailable), use `./deploy.sh`.
+
 ### Execution Flow
 
 1. Load/build a `Workflow` (validates DAG structure, no cycles, types match)

--- a/release.sh
+++ b/release.sh
@@ -170,10 +170,15 @@ uv run pytest -q
 # Run linting
 echo "Running linting..."
 uv run ruff check .
+uv run ruff format --check .
+
+# Run type checking
+echo "Running type checking..."
+uv run pyright
 
 # Commit version bump
 echo "Committing version bump..."
-git add pyproject.toml src/workflow_engine/__init__.py
+git add pyproject.toml src/workflow_engine/__init__.py uv.lock
 git commit -m "Bump version to $NEW_VERSION"
 
 # Create and push tag


### PR DESCRIPTION
## Summary

- Adds a **Release Process** section to `CLAUDE.md` documenting the steps to cut a release: update the changelog (by studying commits since the last tag), run `./release.sh` from a clean up-to-date `main` branch, and notes on PyPI publishing via GitHub Actions or `./deploy.sh`
- Fixes `release.sh` to include `uv.lock` in the version bump commit — it was being updated by `uv run pytest` after the version change but left uncommitted, causing post-release dirty state
- Syncs `release.sh` with `deploy.sh`: adds `ruff format --check` and `pyright` to the pre-release checks

## Test plan

- [ ] Verify `CLAUDE.md` release section reads clearly
- [ ] Cut next RC and confirm `uv.lock` is included in the bump commit with no leftover dirty state
- [ ] Confirm `pyright` and `ruff format --check` gate the release on type/format errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)