### PR TITLE
Allow on_node_start to short-circuit expanded nodes

### DIFF
--- a/src/workflow_engine/core/context.py
+++ b/src/workflow_engine/core/context.py
@@ -9,7 +9,7 @@ from .error import ShouldRetry, ShouldYield, WorkflowErrors
 from .execution import WorkflowExecutionResult
 from .node import Node, NodeRegistry
 from .values import Data, DataMapping, FileValue, ValueRegistry
-from .workflow import ValidatedWorkflow
+from .workflow import ValidatedWorkflow, Workflow
 
 F = TypeVar("F", bound=FileValue)
 
@@ -83,7 +83,7 @@ class ExecutionContext(ABC, EnforceOverrides):
         input_type: type[Data],
         output_type: type[Data],
         input: DataMapping,
-    ) -> DataMapping | None:
+    ) -> DataMapping | Workflow | None:
         """
         A hook that is called when a node starts execution.
 

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -404,25 +404,27 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
                 output_type=output_type,
                 input=casted_input,
             )
-            if output is not None:
-                return output
-            output_obj = await self.run(
-                context=context,
-                input_type=input_type,
-                output_type=output_type,
-                input=input_obj,
-            )
 
             from .workflow import (
                 ValidatedWorkflow,
                 Workflow,
             )  # lazy to avoid circular import
 
-            if isinstance(output_obj, Workflow):
-                if not isinstance(output_obj, ValidatedWorkflow):
-                    workflow = await output_obj.validate(context.validation_context)
+            if output is None:
+                output = await self.run(
+                    context=context,
+                    input_type=input_type,
+                    output_type=output_type,
+                    input=input_obj,
+                )
+                if not isinstance(output, Workflow):
+                    output = get_data_dict(output)
+
+            if isinstance(output, Workflow):
+                if not isinstance(output, ValidatedWorkflow):
+                    workflow = await output.validate(context.validation_context)
                 else:
-                    workflow = output_obj
+                    workflow = output
                 output = await context.on_node_expand(
                     node=self,
                     input_type=input_type,
@@ -439,7 +441,7 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
                     input_type=input_type,
                     output_type=output_type,
                     input=casted_input,
-                    output=get_data_dict(output_obj),
+                    output=output,
                 )
             logger.info("Finished node %s", self.id)
             return output

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -262,7 +262,7 @@ class TestOnNodeStart:
             input_type: Type[Data],
             output_type: Type[Data],
             input: DataMapping,
-        ) -> DataMapping | None:
+        ) -> DataMapping | Workflow | None:
             assert isinstance(node, Node)
             assert input_type is not None
             assert output_type is not None
@@ -306,7 +306,7 @@ class TestOnNodeStart:
             input_type: Type[Data],
             output_type: Type[Data],
             input: DataMapping,
-        ) -> DataMapping | None:
+        ) -> DataMapping | Workflow | None:
             assert isinstance(node, Node)
             assert input_type is not None
             assert output_type is not None
@@ -332,6 +332,102 @@ class TestOnNodeStart:
 
         assert result.status is WorkflowExecutionResultStatus.SUCCESS
         assert result.output == {"value": StringValue("cached")}
+
+    @pytest.mark.asyncio
+    async def test_can_short_circuit_expanding_node(self):
+        """Returning a Workflow from on_node_start bypasses run() and triggers expansion."""
+        workflow = _expanding_workflow()
+        context = InMemoryExecutionContext()
+        run_called = False
+        expand_called = False
+
+        original_on_node_start = context.on_node_start
+        original_on_node_expand = context.on_node_expand
+
+        # Build a replacement workflow to return from on_node_start
+        replacement_input = InputNode.empty()
+        replacement_output = OutputNode.from_fields(value=StringValue)
+        replacement_constant = ConstantStringNode.from_value(
+            id="replacement_constant", value="short-circuited"
+        )
+        replacement_workflow = Workflow(
+            input_node=replacement_input,
+            output_node=replacement_output,
+            inner_nodes=[replacement_constant],
+            edges=[
+                Edge.from_nodes(
+                    source=replacement_constant,
+                    source_key="value",
+                    target=replacement_output,
+                    target_key="value",
+                )
+            ],
+        )
+
+        async def on_node_start(
+            *,
+            node: Node,
+            input_type: Type[Data],
+            output_type: Type[Data],
+            input: DataMapping,
+        ) -> DataMapping | Workflow | None:
+            if node.id == "expanding":
+                return replacement_workflow
+            return await original_on_node_start(
+                node=node,
+                input_type=input_type,
+                output_type=output_type,
+                input=input,
+            )
+
+        async def on_node_expand(
+            *,
+            node: Node,
+            input_type: Type[Data],
+            output_type: Type[Data],
+            input: DataMapping,
+            workflow: ValidatedWorkflow,
+        ) -> DataMapping:
+            nonlocal expand_called
+            expand_called = True
+            return await original_on_node_expand(
+                node=node,
+                input_type=input_type,
+                output_type=output_type,
+                input=input,
+                workflow=workflow,
+            )
+
+        # Patch run to detect if it's called on the expanding node
+        original_run = ExpandingNode.run
+
+        async def patched_run(self, **kwargs):
+            nonlocal run_called
+            if self.id == "expanding":
+                run_called = True
+            return await original_run(self, **kwargs)
+
+        context.on_node_start = on_node_start
+        context.on_node_expand = on_node_expand
+
+        algorithm = TopologicalExecutionAlgorithm()
+        engine = WorkflowEngine(execution_algorithm=algorithm)
+
+        import unittest.mock
+
+        with unittest.mock.patch.object(ExpandingNode, "run", patched_run):
+            result = await engine.execute(
+                context=context,
+                workflow=workflow,
+                input={},
+            )
+
+        assert result.status is WorkflowExecutionResultStatus.SUCCESS
+        assert not run_called, (
+            "run() should not be called when on_node_start returns a Workflow"
+        )
+        assert expand_called, "on_node_expand should still be called"
+        assert result.output == {"value": StringValue("short-circuited")}
 
 
 class TestOnNodeFinish:
@@ -715,7 +811,7 @@ class TestOnWorkflowStart:
             input_type: Type[Data],
             output_type: Type[Data],
             input: DataMapping,
-        ) -> DataMapping | None:
+        ) -> DataMapping | Workflow | None:
             node_start_ids.append(node.id)
             return await original_on_node_start(
                 node=node,


### PR DESCRIPTION
## Summary
- `on_node_start` return type changed from `DataMapping | None` to `DataMapping | Workflow | None`
- `Node.__call__` updated so a `Workflow` returned by `on_node_start` skips `run()` and flows into `on_node_expand`, matching how `run()`-returned workflows are handled
- Added test verifying that returning a `Workflow` from `on_node_start` bypasses `run()`, triggers `on_node_expand`, and produces correct output

Closes #88

## Test plan
- [x] New test `test_can_short_circuit_expanding_node` passes
- [x] Existing hook tests still pass (`uv run pytest tests/test_hooks.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)