### PR TITLE
Add YAML serialization/deserialization support to all models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "networkx>=3.4.2,<4.0.0",
     "overrides>=7.7.0",
     "pydantic>=2.11.1,<3.0.0",
+    "pyyaml>=6.0.3"
 ]
 
 [project.urls]

--- a/src/workflow_engine/core/edge.py
+++ b/src/workflow_engine/core/edge.py
@@ -6,7 +6,7 @@ from typing import Self
 
 from pydantic import model_validator
 
-from ..utils.immutable import ImmutableBaseModel
+from ..utils.model import ImmutableBaseModel
 from .node import Node
 from .values import Data, resolve_path
 

--- a/src/workflow_engine/core/error.py
+++ b/src/workflow_engine/core/error.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Self
 
 from pydantic import Field
 
-from ..utils.immutable import ImmutableBaseModel
+from ..utils.model import ImmutableBaseModel
 from .stakeholder import StakeholderLevel
 
 if TYPE_CHECKING:

--- a/src/workflow_engine/core/execution.py
+++ b/src/workflow_engine/core/execution.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Mapping, Self
 from overrides import EnforceOverrides
 from pydantic import Field
 
-from ..utils.immutable import ImmutableBaseModel
+from ..utils.model import ImmutableBaseModel
 from .error import WorkflowErrors
 from .values import DataMapping
 from .workflow import ValidatedWorkflow

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -26,7 +26,7 @@ from pydantic import ConfigDict, Field, ValidationError, model_validator
 from typing_extensions import overload
 
 from ..utils.asynchronous import gather
-from ..utils.immutable import ImmutableBaseModel
+from ..utils.model import ImmutableBaseModel
 from ..utils.semver import (
     LATEST_SEMANTIC_VERSION,
     SEMANTIC_VERSION_OR_LATEST_PATTERN,

--- a/src/workflow_engine/core/values/data.py
+++ b/src/workflow_engine/core/values/data.py
@@ -8,8 +8,8 @@ from pydantic import ConfigDict, create_model
 from pydantic.fields import FieldInfo
 
 from ...utils.asynchronous import gather
-from ...utils.immutable import ImmutableBaseModel
 from ...utils.iter import only
+from ...utils.model import ImmutableBaseModel
 from .mapping import StringMapValue
 from .value import Caster, Value, ValueType, get_origin_and_args
 

--- a/src/workflow_engine/core/values/extraction.py
+++ b/src/workflow_engine/core/values/extraction.py
@@ -1,11 +1,12 @@
 # workflow_engine/core/values/extraction.py
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from ...utils.model import ImmutableBaseModel
 from .model import ModelValue
 
 
-class Entity(BaseModel):
+class Entity(ImmutableBaseModel):
     """An extracted entity from a document."""
 
     id: str
@@ -14,7 +15,7 @@ class Entity(BaseModel):
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
-class Relation(BaseModel):
+class Relation(ImmutableBaseModel):
     """A relation between two entities."""
 
     id: str
@@ -24,7 +25,7 @@ class Relation(BaseModel):
     confidence: float | None = Field(default=None, ge=0.0, le=1.0)
 
 
-class ExtractionResult(BaseModel):
+class ExtractionResult(ImmutableBaseModel):
     """Result of an entity/relation extraction from a document."""
 
     document_id: str

--- a/src/workflow_engine/core/values/file.py
+++ b/src/workflow_engine/core/values/file.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from pydantic import ConfigDict, Field
 
-from ...utils.immutable import ImmutableBaseModel
+from ...utils.model import ImmutableBaseModel
 from .value import Value
 
 if TYPE_CHECKING:

--- a/src/workflow_engine/core/values/schema.py
+++ b/src/workflow_engine/core/values/schema.py
@@ -24,7 +24,7 @@ from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
 from ...utils.hash import json_digest
-from ...utils.immutable import ImmutableBaseModel
+from ...utils.model import ImmutableBaseModel
 from .data import Data, DataValue, build_data_type
 from .mapping import StringMapValue
 from .primitives import (

--- a/src/workflow_engine/core/values/value.py
+++ b/src/workflow_engine/core/values/value.py
@@ -24,7 +24,7 @@ from overrides import override
 from pydantic import PrivateAttr
 
 from ...utils.asynchronous import is_coroutine
-from ...utils.immutable import ImmutableRootModel
+from ...utils.model import ImmutableRootModel
 
 if TYPE_CHECKING:
     from ..context import ExecutionContext

--- a/src/workflow_engine/core/workflow.py
+++ b/src/workflow_engine/core/workflow.py
@@ -11,7 +11,7 @@ from overrides import override
 from pydantic import ConfigDict, Field, ValidationError, model_validator
 
 from ..utils.asynchronous import gather
-from ..utils.immutable import ImmutableBaseModel
+from ..utils.model import ImmutableBaseModel
 from .edge import Edge
 from .error import NodeException, NodeExpansionException, WorkflowException
 from .io import InputNode, OutputNode

--- a/src/workflow_engine/execution/rate_limit.py
+++ b/src/workflow_engine/execution/rate_limit.py
@@ -9,7 +9,7 @@ import asyncio
 import time
 from datetime import timedelta
 
-from ..utils.immutable import ImmutableBaseModel
+from ..utils.model import ImmutableBaseModel
 
 
 class RateLimitConfig(ImmutableBaseModel):

--- a/src/workflow_engine/utils/model.py
+++ b/src/workflow_engine/utils/model.py
@@ -1,7 +1,22 @@
 from collections.abc import MutableMapping
 from typing import Any, Generic, Self, TypeVar
 
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
+from pydantic import RootModel as PydanticRootModel
+
+from .serialization import PydanticYamlMixin
+
+T = TypeVar("T")
+
+
+class BaseModel(PydanticBaseModel, PydanticYamlMixin):
+    pass
+
+
+class RootModel(PydanticRootModel[T], PydanticYamlMixin, Generic[T]):
+    pass
+
 
 _immutable_model_config = ConfigDict(
     frozen=True,
@@ -65,7 +80,17 @@ class ImmutableRootModel(RootModel[T], _ImmutableMixin, Generic[T]):
     pass
 
 
+class MutableBaseModel(BaseModel):
+    pass
+
+
+class MutableRootModel(RootModel[T], Generic[T]):
+    pass
+
+
 __all__ = [
     "ImmutableBaseModel",
     "ImmutableRootModel",
+    "MutableBaseModel",
+    "MutableRootModel",
 ]

--- a/src/workflow_engine/utils/serialization.py
+++ b/src/workflow_engine/utils/serialization.py
@@ -31,13 +31,19 @@ def dumps_yaml(data: Any) -> str:
 class PydanticYamlMixin:
     @classmethod
     def model_validate_yaml(cls, stream: TextIO | str) -> Self:
-        assert issubclass(cls, BaseModel)
+        if not issubclass(cls, BaseModel):
+            raise TypeError(
+                f"{cls.__name__}.model_validate_yaml() requires cls to inherit from BaseModel"
+            )
         if isinstance(stream, str):
             return cls.model_validate(loads_yaml(stream))
         return cls.model_validate(load_yaml(stream))
 
     def model_dump_yaml(self) -> str:
-        assert isinstance(self, BaseModel)
+        if not isinstance(self, BaseModel):
+            raise TypeError(
+                f"{self.__class__.__name__}.model_dump_yaml() requires self to be a BaseModel instance"
+            )
         return dumps_yaml(self.model_dump(mode="json"))
 
 

--- a/src/workflow_engine/utils/serialization.py
+++ b/src/workflow_engine/utils/serialization.py
@@ -5,8 +5,8 @@ from yaml import dump as yaml_dump
 from yaml import load as yaml_load
 
 try:
-    from yaml import CDumper as YamlDumper
-    from yaml import CLoader as YamlLoader
+    from yaml import CSafeDumper as YamlDumper
+    from yaml import CSafeLoader as YamlLoader
 except ImportError:
     from yaml import SafeDumper as YamlDumper
     from yaml import SafeLoader as YamlLoader

--- a/src/workflow_engine/utils/serialization.py
+++ b/src/workflow_engine/utils/serialization.py
@@ -1,0 +1,50 @@
+from typing import Any, Self, TextIO
+
+from pydantic import BaseModel
+from yaml import dump as yaml_dump
+from yaml import load as yaml_load
+
+try:
+    from yaml import CDumper as YamlDumper
+    from yaml import CLoader as YamlLoader
+except ImportError:
+    from yaml import SafeDumper as YamlDumper
+    from yaml import SafeLoader as YamlLoader
+
+
+def load_yaml(stream: TextIO) -> Any:
+    return yaml_load(stream, Loader=YamlLoader)
+
+
+def loads_yaml(s: str) -> Any:
+    return yaml_load(s, Loader=YamlLoader)
+
+
+def dump_yaml(data: Any, stream: TextIO) -> None:
+    yaml_dump(data, stream, Dumper=YamlDumper)
+
+
+def dumps_yaml(data: Any) -> str:
+    return yaml_dump(data, Dumper=YamlDumper)
+
+
+class PydanticYamlMixin:
+    @classmethod
+    def model_validate_yaml(cls, stream: TextIO | str) -> Self:
+        assert issubclass(cls, BaseModel)
+        if isinstance(stream, str):
+            return cls.model_validate(loads_yaml(stream))
+        return cls.model_validate(load_yaml(stream))
+
+    def model_dump_yaml(self) -> str:
+        assert isinstance(self, BaseModel)
+        return dumps_yaml(self.model_dump(mode="json"))
+
+
+__all__ = [
+    "PydanticYamlMixin",
+    "dump_yaml",
+    "dumps_yaml",
+    "load_yaml",
+    "loads_yaml",
+]

--- a/tests/test_immutable.py
+++ b/tests/test_immutable.py
@@ -3,7 +3,7 @@ from typing import ClassVar
 import pytest
 from pydantic import ConfigDict, ValidationError
 
-from workflow_engine.utils.immutable import (
+from workflow_engine.utils.model import (
     ImmutableBaseModel,
     ImmutableRootModel,
 )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,86 @@
+import io
+
+import pytest
+from pydantic import BaseModel
+
+from workflow_engine.utils.model import BaseModel as WEBaseModel
+from workflow_engine.utils.model import RootModel as WERootModel
+from workflow_engine.utils.serialization import (
+    PydanticYamlMixin,
+    dumps_yaml,
+    load_yaml,
+    loads_yaml,
+)
+
+
+class Sample(WEBaseModel):
+    name: str
+    age: int
+
+
+class SampleRoot(WERootModel[list[int]]):
+    pass
+
+
+def test_loads_yaml_roundtrip():
+    data = {"a": 1, "b": [1, 2, 3]}
+    assert loads_yaml(dumps_yaml(data)) == data
+
+
+def test_load_yaml_from_stream():
+    yaml_str = "a: 1\nb: 2\n"
+    assert load_yaml(io.StringIO(yaml_str)) == {"a": 1, "b": 2}
+
+
+def test_model_validate_yaml_from_string():
+    model = Sample.model_validate_yaml("name: alice\nage: 30\n")
+    assert model == Sample(name="alice", age=30)
+
+
+def test_model_validate_yaml_from_stream():
+    model = Sample.model_validate_yaml(io.StringIO("name: bob\nage: 25\n"))
+    assert model == Sample(name="bob", age=25)
+
+
+def test_model_dump_yaml_roundtrip():
+    original = Sample(name="carol", age=42)
+    dumped = original.model_dump_yaml()
+    assert Sample.model_validate_yaml(dumped) == original
+
+
+def test_model_validate_yaml_root_model():
+    model = SampleRoot.model_validate_yaml("[1, 2, 3]")
+    assert model.root == [1, 2, 3]
+
+
+def test_model_dump_yaml_root_model_roundtrip():
+    original = SampleRoot(root=[4, 5, 6])
+    assert SampleRoot.model_validate_yaml(original.model_dump_yaml()) == original
+
+
+def test_model_validate_yaml_requires_base_model():
+    class NotAModel(PydanticYamlMixin):
+        pass
+
+    with pytest.raises(TypeError, match="requires cls to inherit from BaseModel"):
+        NotAModel.model_validate_yaml("foo: bar")
+
+
+def test_model_dump_yaml_requires_base_model_instance():
+    class NotAModel(PydanticYamlMixin):
+        pass
+
+    with pytest.raises(TypeError, match="requires self to be a BaseModel instance"):
+        NotAModel().model_dump_yaml()
+
+
+def test_model_validate_yaml_validation_error():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Sample.model_validate_yaml("name: dave\nage: not_a_number\n")
+
+
+def test_pydantic_yaml_mixin_is_inherited():
+    assert issubclass(Sample, PydanticYamlMixin)
+    assert issubclass(Sample, BaseModel)

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "networkx" },
     { name = "overrides" },
     { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -33,6 +34,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.4.2,<4.0.0" },
     { name = "overrides", specifier = ">=7.7.0" },
     { name = "pydantic", specifier = ">=2.11.1,<3.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Towards the #114 `engine.yaml` goal, this PR adds YAML serialization/deserialization to the base `ImmutableBaseModel` and a new `MutableBaseModel` cousin.

See https://pyyaml.org/wiki/PyYAMLDocumentation#installation

Eventually the config will be a subclass of this base model type, giving us yaml loading for free.

We might want to consider TOML too at some point but personally I'm not a fan of TOML