### PR TITLE
Fix WorkflowException serialization in LocalContext.on_node_error

### DIFF
--- a/src/workflow_engine/contexts/local.py
+++ b/src/workflow_engine/contexts/local.py
@@ -157,7 +157,7 @@ class LocalContext(ExecutionContext):
     ) -> WorkflowException | DataMapping:
         self._idempotent_write(
             path=self.node_error_path(node.id),
-            data=json.dumps(exception),
+            data=exception.dump().model_dump_json(),
         )
         return exception
 


### PR DESCRIPTION
## Summary
- `LocalContext.on_node_error` called `json.dumps(exception)` on a `WorkflowException`, which raised `TypeError` since `WorkflowException` is a `RuntimeError` subclass, not JSON-serializable.
- Use `exception.dump().model_dump_json()` to convert to the `WorkflowError` Pydantic model and serialize, consistent with how `on_workflow_error` already handles errors.

## Test plan
- [x] `uv run pytest` — 449 passed
- [ ] Manual: trigger a node error against a `LocalContext` and confirm `<node_id>.error.json` is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)