### PR TITLE
Skip parameterized generic aliases in Node auto-registration

### DIFF
--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -200,8 +200,9 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
         # Skip parameterized generic aliases (e.g. `Node[Data, Data, P]`),
         # which Pydantic synthesizes as intermediate classes when a concrete
         # subclass writes `class FooNode(Node[I, O, P])`. They show up here
-        # with names containing `[`. Only concrete subclasses should register.
-        if "[" in cls.__name__:
+        # with bracketed names. Only concrete subclasses should register.
+        name = cls.__name__
+        if "[" in name and "]" in name and name.count("[") == name.count("]"):
             return
 
         NodeRegistry.DEFAULT.register(cls)

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -197,6 +197,13 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
     def __init_subclass__(cls, **kwargs: Unpack[ConfigDict]):
         super().__init_subclass__(**kwargs)  # type: ignore
 
+        # Skip parameterized generic aliases (e.g. `Node[Data, Data, P]`),
+        # which Pydantic synthesizes as intermediate classes when a concrete
+        # subclass writes `class FooNode(Node[I, O, P])`. They show up here
+        # with names containing `[`. Only concrete subclasses should register.
+        if "[" in cls.__name__:
+            return
+
         NodeRegistry.DEFAULT.register(cls)
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Pydantic synthesizes an intermediate `Node[I, O, P]` class when a concrete subclass writes `class FooNode(Node[I, O, P])`. That intermediate's `__init_subclass__` fires too, leaking entries like `Node[Data, Data, SchemaParams]` into `NodeRegistry.DEFAULT`.
- Skip any subclass whose `__name__` contains balanced brackets (the marker of a parameterized generic alias).

Surfaced while prototyping the `wengine` CLI — `wengine node list` was showing the bogus entry.

## Test plan
- [x] `uv run pytest` — 444 passed, 1 xfailed
- [x] `wengine node list` no longer shows `Node[Data, Data, SchemaParams]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)