### PR TITLE
Fix Edge.source_key_path_string for single-segment keys

### DIFF
--- a/src/workflow_engine/core/edge.py
+++ b/src/workflow_engine/core/edge.py
@@ -44,7 +44,7 @@ class Edge(ImmutableBaseModel):
 
     @cached_property
     def source_key_path_string(self) -> str:
-        return ".".join(self.source_key)
+        return ".".join(self.source_key_path)
 
     @classmethod
     def from_nodes(


### PR DESCRIPTION
## Summary
- `Edge.source_key_path_string` calls `".".join(self.source_key)`, which iterates a `str` character-by-character. A `source_key` of `"nums"` rendered as `"n.u.m.s"`.
- Join `source_key_path` instead — that property already normalizes strings into a single-element tuple.

Surfaced while implementing `wengine workflow describe`.

## Test plan
- [x] \`uv run pytest\` — all tests pass
- [x] Verified via CLI: edge \`{source_key: \"nums\"}\` now prints \`input.nums\` instead of \`input.n.u.m.s\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)