### PR TITLE
Add workflow editing subcommands to wengine CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,7 +123,15 @@ Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is 
 
 #### `wengine workflow edit <path> update-node <id> <params>`
 
-Replace the params of an existing node, preserving its type and id. Use this to grow or shrink the input/output node's `fields`, or to retune the params of an inner node without removing and re-adding it. Works on input, output, and inner nodes alike.
+Replace the params of an existing node, preserving its type and id. Use this to retune the params of an inner node, or to swap out an entire `fields` dict on the input or output node in one shot. Works on input, output, and inner nodes alike.
+
+#### Field-level convenience commands (input/output nodes only)
+
+For incremental edits to the input or output node's `fields`, three convenience subcommands operate on a single field at a time. The handle is `nodeId.fieldName`. They reject inner nodes — for those, use `update-node`.
+
+- `wengine workflow edit <path> add-field <handle> <schema>` — add a new field. Errors if the field already exists.
+- `wengine workflow edit <path> update-field <handle> <schema>` — replace an existing field's schema. Errors if the field doesn't exist.
+- `wengine workflow edit <path> remove-field <handle>` — remove a field and any edges that reference it.
 
 #### `wengine workflow edit <path> remove-node <id>`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,6 +117,8 @@ Create a blank workflow and store it at `path`. Pass `--force` to overwrite an e
 
 Apply an edit to the workflow stored at `path`. Each edit reloads the file, applies the change, runs full workflow validation, and saves the result back to `path` only if validation succeeds. On failure the file is left untouched.
 
+When a schema-changing edit (`update-node` or `update-field`) makes an existing edge type-incompatible, the edge is dropped automatically and a warning is printed to stderr. This keeps the workflow valid while making the cost of the schema change visible.
+
 #### `wengine workflow edit <path> add-node <name> <id> [params]`
 
 Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is a JSON literal, `@file.json`, or `-` for stdin (defaults to `{}`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,29 +113,29 @@ Run a single node.
 
 Create a blank workflow and store it at `path`. Pass `--force` to overwrite an existing file. (Template support is planned but not yet implemented.)
 
-### `wengine workflow edit <path> [command]`
+### `wengine workflow edit <path> <subcommand>`
 
-> Avoid implementing this in the first iteration of the CLI; it's tricky to get these right.
+Apply an edit to the workflow stored at `path`. Each edit reloads the file, applies the change, runs full workflow validation, and saves the result back to `path` only if validation succeeds. On failure the file is left untouched.
 
-Apply an edit to the workflow stored at `path`, and save it back to the same file if the result is valid.
+#### `wengine workflow edit <path> add-node <name> <id> [params]`
 
-#### `wengine workflow edit <path> add-node <name> <id> <params>`
+Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is a JSON literal, `@file.json`, or `-` for stdin (defaults to `{}`).
 
 #### `wengine workflow edit <path> remove-node <id>`
 
-Deletes all edges associated with that node too.
-
-#### `wengine workflow edit <path> possible-edges <nodeId>.<handle>`
-
-Locates all sources or targets that the given handle can connect to in a type-safe way. Doesn't edit the workflow.
+Remove an inner node and any edges that touch it. Refuses to remove the workflow's input or output node.
 
 #### `wengine workflow edit <path> add-edge <source> <target>`
 
-Validates that the edge can be added.
+Add an edge `source -> target`, where each side is formatted as `nodeId.handle`. Type compatibility is enforced by the validation step.
 
 #### `wengine workflow edit <path> remove-edge <source> <target>`
 
-where `source` and `target` are of the format `nodeId.handle`.
+Remove the edge `source -> target`. Errors if no matching edge exists.
+
+#### `wengine workflow edit <path> possible-edges <nodeId>.<handle>`
+
+For the given handle (an output or input on the named node), list all compatible counterparts on other nodes. Uses `Value.can_cast_to` to determine compatibility. Already-wired inputs are excluded (each input takes one source). Doesn't modify the workflow.
 
 ### `wengine workflow check <path>`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,6 +121,10 @@ Apply an edit to the workflow stored at `path`. Each edit reloads the file, appl
 
 Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is a JSON literal, `@file.json`, or `-` for stdin (defaults to `{}`).
 
+#### `wengine workflow edit <path> update-node <id> <params>`
+
+Replace the params of an existing node, preserving its type and id. Use this to grow or shrink the input/output node's `fields`, or to retune the params of an inner node without removing and re-adding it. Works on input, output, and inner nodes alike.
+
 #### `wengine workflow edit <path> remove-node <id>`
 
 Remove an inner node and any edges that touch it. Refuses to remove the workflow's input or output node.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,17 +113,17 @@ Run a single node.
 
 Create a blank workflow and store it at `path`. Pass `--force` to overwrite an existing file. (Template support is planned but not yet implemented.)
 
-### `wengine workflow edit <path> <subcommand>`
+### `wengine workflow edit <subcommand> <path> ...`
 
 Apply an edit to the workflow stored at `path`. Each edit reloads the file, applies the change, runs full workflow validation, and saves the result back to `path` only if validation succeeds. On failure the file is left untouched.
 
 When a schema-changing edit (`update-node` or `update-field`) makes an existing edge type-incompatible, the edge is dropped automatically and a warning is printed to stderr. This keeps the workflow valid while making the cost of the schema change visible.
 
-#### `wengine workflow edit <path> add-node <name> <id> [params]`
+#### `wengine workflow edit add-node <path> <name> <id> [params]`
 
 Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is a JSON literal, `@file.json`, or `-` for stdin (defaults to `{}`).
 
-#### `wengine workflow edit <path> update-node <id> <params>`
+#### `wengine workflow edit update-node <path> <id> <params>`
 
 Replace the params of an existing node, preserving its type and id. Use this to retune the params of an inner node, or to swap out an entire `fields` dict on the input or output node in one shot. Works on input, output, and inner nodes alike.
 
@@ -131,23 +131,23 @@ Replace the params of an existing node, preserving its type and id. Use this to 
 
 For incremental edits to the input or output node's `fields`, three convenience subcommands operate on a single field at a time. The handle is `nodeId.fieldName`. They reject inner nodes — for those, use `update-node`.
 
-- `wengine workflow edit <path> add-field <handle> <schema>` — add a new field. Errors if the field already exists.
-- `wengine workflow edit <path> update-field <handle> <schema>` — replace an existing field's schema. Errors if the field doesn't exist.
-- `wengine workflow edit <path> remove-field <handle>` — remove a field and any edges that reference it.
+- `wengine workflow edit add-field <path> <handle> <schema>` — add a new field. Errors if the field already exists.
+- `wengine workflow edit update-field <path> <handle> <schema>` — replace an existing field's schema. Errors if the field doesn't exist.
+- `wengine workflow edit remove-field <path> <handle>` — remove a field and any edges that reference it.
 
-#### `wengine workflow edit <path> remove-node <id>`
+#### `wengine workflow edit remove-node <path> <id>`
 
 Remove an inner node and any edges that touch it. Refuses to remove the workflow's input or output node.
 
-#### `wengine workflow edit <path> add-edge <source> <target>`
+#### `wengine workflow edit add-edge <path> <source> <target>`
 
-Add an edge `source -> target`, where each side is formatted as `nodeId.handle`. Type compatibility is enforced by the validation step.
+Add an edge `source -> target`, where each side is formatted as `nodeId.handle`. The source handle may use a dotted path (e.g. `node.struct.field`) to address a nested output field; the target handle must be a single segment. Type compatibility is enforced by the validation step.
 
-#### `wengine workflow edit <path> remove-edge <source> <target>`
+#### `wengine workflow edit remove-edge <path> <source> <target>`
 
 Remove the edge `source -> target`. Errors if no matching edge exists.
 
-#### `wengine workflow edit <path> possible-edges <nodeId>.<handle>`
+#### `wengine workflow edit possible-edges <path> <nodeId>.<handle>`
 
 For the given handle (an output or input on the named node), list all compatible counterparts on other nodes. Uses `Value.can_cast_to` to determine compatibility. Already-wired inputs are excluded (each input takes one source). Doesn't modify the workflow.
 

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -326,12 +326,15 @@ def _save_workflow(path: Path, wf: Workflow) -> None:
 async def _prune_incompatible_edges(
     engine: WorkflowEngine, wf: Workflow
 ) -> tuple[Workflow, list[str]]:
-    """Drop edges whose endpoints are no longer type-compatible.
+    """Drop edges that fail per-edge type validation against the resolved nodes.
 
     Returns (possibly-updated workflow, list of human-readable descriptions of
     dropped edges). The caller is responsible for surfacing the warnings.
-    Edges referencing missing nodes/keys are left in place so the subsequent
-    full validation can produce a clearer error.
+    Edges referencing missing nodes are left in place (no resolved type to
+    check against), but edges whose handles can't be resolved on existing
+    nodes — e.g. a stale source field — are pruned the same way as outright
+    type mismatches. The follow-up full validation will surface any structural
+    errors that survive pruning.
     """
     # Validate a copy without edges to recover per-node resolved I/O types.
     # (Going through the engine ensures discriminator dispatch produces the
@@ -390,7 +393,7 @@ async def workflow_check(path: Path, config_path: Path | None):
     """Validate a workflow and print its input/output schemas."""
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
-    validated = await engine.validate(wf)
+    validated = await _validate_or_die(engine, wf)
     out = {
         "ok": True,
         "input_schema": validated.input_type.model_json_schema(),
@@ -436,7 +439,7 @@ async def workflow_describe(path: Path, as_json: bool, config_path: Path | None)
 
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
-    validated = await engine.validate(wf)
+    validated = await _validate_or_die(engine, wf)
 
     nodes_summary = [
         {
@@ -624,6 +627,8 @@ async def edit_add_field(
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
     node_id, field_name = _parse_handle(handle)
+    if node_id not in wf.nodes_by_id:
+        raise click.ClickException(f"Node id {node_id!r} not found.")
     schema_obj = _load_input(schema_arg)
     current = dict(
         wf.nodes_by_id[node_id].params.model_dump(mode="json").get("fields", {})
@@ -652,6 +657,8 @@ async def edit_update_field(
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
     node_id, field_name = _parse_handle(handle)
+    if node_id not in wf.nodes_by_id:
+        raise click.ClickException(f"Node id {node_id!r} not found.")
     schema_obj = _load_input(schema_arg)
     current = dict(
         wf.nodes_by_id[node_id].params.model_dump(mode="json").get("fields", {})
@@ -683,6 +690,8 @@ async def edit_remove_field(path: Path, handle: str, config_path: Path | None):
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
     node_id, field_name = _parse_handle(handle)
+    if node_id not in wf.nodes_by_id:
+        raise click.ClickException(f"Node id {node_id!r} not found.")
     current = dict(
         wf.nodes_by_id[node_id].params.model_dump(mode="json").get("fields", {})
     )
@@ -741,14 +750,28 @@ async def edit_remove_node(path: Path, node_id: str, config_path: Path | None):
 @config_option
 @coro
 async def edit_add_edge(path: Path, source: str, target: str, config_path: Path | None):
-    """Add an edge SOURCE -> TARGET (each formatted as 'nodeId.handle')."""
+    """Add an edge SOURCE -> TARGET.
+
+    SOURCE is `nodeId.handle` and may use a dotted path to address a nested
+    output field (e.g. `node.struct.field`). TARGET is `nodeId.handle` and
+    must be a single segment — the engine doesn't support writes into nested
+    target fields.
+    """
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
     src_id, src_key = _parse_handle(source)
     tgt_id, tgt_key = _parse_handle(target)
+    if "." in tgt_key:
+        raise click.ClickException(
+            f"Target handle {target!r} must be a single segment "
+            f"(nested target paths are not supported)."
+        )
+    source_key_value: str | list[str] = (
+        src_key.split(".") if "." in src_key else src_key
+    )
     new_edge = Edge(
         source_id=src_id,
-        source_key=src_key,
+        source_key=source_key_value,
         target_id=tgt_id,
         target_key=tgt_key,
     )
@@ -767,11 +790,15 @@ async def edit_add_edge(path: Path, source: str, target: str, config_path: Path 
 async def edit_remove_edge(
     path: Path, source: str, target: str, config_path: Path | None
 ):
-    """Remove the edge SOURCE -> TARGET."""
+    """Remove the edge SOURCE -> TARGET. SOURCE may use a dotted nested path."""
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
     src_id, src_key = _parse_handle(source)
     tgt_id, tgt_key = _parse_handle(target)
+    if "." in tgt_key:
+        raise click.ClickException(
+            f"Target handle {target!r} must be a single segment."
+        )
 
     def matches(e: Edge) -> bool:
         return (
@@ -804,7 +831,7 @@ async def edit_possible_edges(path: Path, handle: str, config_path: Path | None)
     """
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
-    validated = await engine.validate(wf)
+    validated = await _validate_or_die(engine, wf)
 
     node_id, key = _parse_handle(handle)
     if node_id not in validated.nodes_by_id:

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -323,6 +323,47 @@ def _save_workflow(path: Path, wf: Workflow) -> None:
         path.write_text(wf.model_dump_json(indent=2) + "\n")
 
 
+async def _prune_incompatible_edges(
+    engine: WorkflowEngine, wf: Workflow
+) -> tuple[Workflow, list[str]]:
+    """Drop edges whose endpoints are no longer type-compatible.
+
+    Returns (possibly-updated workflow, list of human-readable descriptions of
+    dropped edges). The caller is responsible for surfacing the warnings.
+    Edges referencing missing nodes/keys are left in place so the subsequent
+    full validation can produce a clearer error.
+    """
+    # Validate a copy without edges to recover per-node resolved I/O types.
+    # (Going through the engine ensures discriminator dispatch produces the
+    # concrete node subclass — calling node.input_type directly on a freshly
+    # deserialized Node fails with NotImplementedError.)
+    wf_no_edges = wf.model_copy(update={"edges": ()})
+    try:
+        validated = await engine.validate(wf_no_edges)
+    except Exception:
+        return wf, []
+
+    surviving: list[Edge] = []
+    dropped: list[str] = []
+    for edge in wf.edges:
+        src_t = validated.node_output_types.get(edge.source_id)
+        tgt_t = validated.node_input_types.get(edge.target_id)
+        if src_t is None or tgt_t is None:
+            surviving.append(edge)
+            continue
+        try:
+            edge.validate_types(source_type=src_t, target_type=tgt_t)
+            surviving.append(edge)
+        except Exception:
+            dropped.append(
+                f"{edge.source_id}.{'.'.join(edge.source_key_path)} -> "
+                f"{edge.target_id}.{edge.target_key}"
+            )
+    if not dropped:
+        return wf, []
+    return wf.model_copy(update={"edges": tuple(surviving)}), dropped
+
+
 async def _validate_or_die(engine: WorkflowEngine, wf: Workflow):
     """Validate `wf` via `engine`; convert engine errors to ClickException."""
     try:
@@ -538,8 +579,11 @@ async def edit_update_node(
     else:
         new_inner = tuple(new_node if n.id == node_id else n for n in wf.inner_nodes)
         new_wf = wf.model_copy(update={"inner_nodes": new_inner})
+    new_wf, dropped = await _prune_incompatible_edges(engine, new_wf)
     await _validate_or_die(engine, new_wf)
     _save_workflow(path, new_wf)
+    for d in dropped:
+        click.echo(f"warning: dropped now-incompatible edge {d}", err=True)
     click.echo(f"Updated params on node {node_id!r}.")
 
 
@@ -618,8 +662,11 @@ async def edit_update_field(
         )
     current[field_name] = schema_obj
     new_wf = await _apply_fields_change(engine, wf, node_id, current)
+    new_wf, dropped = await _prune_incompatible_edges(engine, new_wf)
     await _validate_or_die(engine, new_wf)
     _save_workflow(path, new_wf)
+    for d in dropped:
+        click.echo(f"warning: dropped now-incompatible edge {d}", err=True)
     click.echo(f"Updated field {handle}.")
 
 

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -494,11 +494,53 @@ async def edit_add_node(
     if node_id in wf.nodes_by_id:
         raise click.ClickException(f"Node id {node_id!r} already exists in workflow.")
     params = _load_input(params_arg)
-    new_node = engine.create_node(name, id=node_id, params=params)
+    try:
+        new_node = engine.create_node(name, id=node_id, params=params)
+    except Exception as e:
+        raise click.ClickException(f"Failed to create node {node_id!r}: {e}") from e
     new_wf = wf.model_copy(update={"inner_nodes": (*wf.inner_nodes, new_node)})
     await _validate_or_die(engine, new_wf)
     _save_workflow(path, new_wf)
     click.echo(f"Added node {node_id!r} ({name}).")
+
+
+@workflow_edit.command("update-node")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("node_id", metavar="ID")
+@click.argument("params_arg", metavar="PARAMS")
+@config_option
+@coro
+async def edit_update_node(
+    path: Path,
+    node_id: str,
+    params_arg: str,
+    config_path: Path | None,
+):
+    """Replace the params of an existing node (preserving its type and id).
+
+    Use this to grow/shrink the input or output node's `fields`, or to retune
+    the params of an inner node without removing and re-adding it.
+    """
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    if node_id not in wf.nodes_by_id:
+        raise click.ClickException(f"Node id {node_id!r} not found.")
+    target_node = wf.nodes_by_id[node_id]
+    new_params = _load_input(params_arg)
+    try:
+        new_node = engine.create_node(target_node.type, id=node_id, params=new_params)
+    except Exception as e:
+        raise click.ClickException(f"Invalid params for node {node_id!r}: {e}") from e
+    if node_id == wf.input_node.id:
+        new_wf = wf.model_copy(update={"input_node": new_node})
+    elif node_id == wf.output_node.id:
+        new_wf = wf.model_copy(update={"output_node": new_node})
+    else:
+        new_inner = tuple(new_node if n.id == node_id else n for n in wf.inner_nodes)
+        new_wf = wf.model_copy(update={"inner_nodes": new_inner})
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Updated params on node {node_id!r}.")
 
 
 @workflow_edit.command("remove-node")

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -543,6 +543,124 @@ async def edit_update_node(
     click.echo(f"Updated params on node {node_id!r}.")
 
 
+async def _apply_fields_change(
+    engine: WorkflowEngine,
+    wf: Workflow,
+    node_id: str,
+    new_fields: dict[str, Any],
+) -> Workflow:
+    """Return a workflow where the named input/output node's `fields` is replaced."""
+    if node_id not in (wf.input_node.id, wf.output_node.id):
+        raise click.ClickException(
+            f"Field-level edits only work on the input or output node "
+            f"(got {node_id!r}). For inner nodes, use `update-node`."
+        )
+    target_node = wf.input_node if node_id == wf.input_node.id else wf.output_node
+    try:
+        new_node = engine.create_node(
+            target_node.type, id=node_id, params={"fields": new_fields}
+        )
+    except Exception as e:
+        raise click.ClickException(f"Invalid fields for node {node_id!r}: {e}") from e
+    if node_id == wf.input_node.id:
+        return wf.model_copy(update={"input_node": new_node})
+    return wf.model_copy(update={"output_node": new_node})
+
+
+@workflow_edit.command("add-field")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("handle")
+@click.argument("schema_arg", metavar="SCHEMA")
+@config_option
+@coro
+async def edit_add_field(
+    path: Path, handle: str, schema_arg: str, config_path: Path | None
+):
+    """Add a single field to an input/output node. HANDLE is `nodeId.fieldName`."""
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    node_id, field_name = _parse_handle(handle)
+    schema_obj = _load_input(schema_arg)
+    current = dict(
+        wf.nodes_by_id[node_id].params.model_dump(mode="json").get("fields", {})
+    )
+    if field_name in current:
+        raise click.ClickException(
+            f"Field {field_name!r} already exists on node {node_id!r}."
+        )
+    current[field_name] = schema_obj
+    new_wf = await _apply_fields_change(engine, wf, node_id, current)
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Added field {handle}.")
+
+
+@workflow_edit.command("update-field")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("handle")
+@click.argument("schema_arg", metavar="SCHEMA")
+@config_option
+@coro
+async def edit_update_field(
+    path: Path, handle: str, schema_arg: str, config_path: Path | None
+):
+    """Replace the schema of an existing field. HANDLE is `nodeId.fieldName`."""
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    node_id, field_name = _parse_handle(handle)
+    schema_obj = _load_input(schema_arg)
+    current = dict(
+        wf.nodes_by_id[node_id].params.model_dump(mode="json").get("fields", {})
+    )
+    if field_name not in current:
+        raise click.ClickException(
+            f"Field {field_name!r} not found on node {node_id!r}."
+        )
+    current[field_name] = schema_obj
+    new_wf = await _apply_fields_change(engine, wf, node_id, current)
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Updated field {handle}.")
+
+
+@workflow_edit.command("remove-field")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("handle")
+@config_option
+@coro
+async def edit_remove_field(path: Path, handle: str, config_path: Path | None):
+    """Remove a field from an input/output node. HANDLE is `nodeId.fieldName`.
+
+    Also drops any edges referencing the removed field.
+    """
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    node_id, field_name = _parse_handle(handle)
+    current = dict(
+        wf.nodes_by_id[node_id].params.model_dump(mode="json").get("fields", {})
+    )
+    if field_name not in current:
+        raise click.ClickException(
+            f"Field {field_name!r} not found on node {node_id!r}."
+        )
+    del current[field_name]
+    new_wf = await _apply_fields_change(engine, wf, node_id, current)
+
+    def edge_touches_removed_field(e: Edge) -> bool:
+        if e.source_id == node_id and ".".join(e.source_key_path) == field_name:
+            return True
+        if e.target_id == node_id and e.target_key == field_name:
+            return True
+        return False
+
+    new_edges = tuple(e for e in new_wf.edges if not edge_touches_removed_field(e))
+    dropped = len(new_wf.edges) - len(new_edges)
+    new_wf = new_wf.model_copy(update={"edges": new_edges})
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Removed field {handle} and {dropped} associated edge(s).")
+
+
 @workflow_edit.command("remove-node")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.argument("node_id", metavar="ID")

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -20,10 +20,12 @@ from workflow_engine import __version__
 from workflow_engine.contexts.local import LocalContext
 from workflow_engine.core.config import WorkflowEngineConfig
 from workflow_engine.core.context import ValidationContext
+from workflow_engine.core.edge import Edge
 from workflow_engine.core.engine import WorkflowEngine
 from workflow_engine.core.node import NodeRegistry
 from workflow_engine.core.values import ValueRegistry
 from workflow_engine.core.values.schema import validate_value_schema
+from workflow_engine.core.values.value import Value
 from workflow_engine.core.workflow import Workflow
 
 CONFIG_DIR = Path(platformdirs.user_config_dir("wengine", appauthor=False))
@@ -314,6 +316,31 @@ def _load_workflow(path: Path) -> Workflow:
     return Workflow.model_validate_json(text)
 
 
+def _save_workflow(path: Path, wf: Workflow) -> None:
+    if path.suffix in (".yaml", ".yml"):
+        path.write_text(yaml.safe_dump(wf.model_dump(mode="json"), sort_keys=False))
+    else:
+        path.write_text(wf.model_dump_json(indent=2) + "\n")
+
+
+async def _validate_or_die(engine: WorkflowEngine, wf: Workflow):
+    """Validate `wf` via `engine`; convert engine errors to ClickException."""
+    try:
+        return await engine.validate(wf)
+    except Exception as e:
+        raise click.ClickException(f"Workflow failed validation: {e}") from e
+
+
+def _parse_handle(spec: str) -> tuple[str, str]:
+    """Split 'nodeId.handle' into (nodeId, handle)."""
+    if "." not in spec:
+        raise click.ClickException(f"Expected 'nodeId.handle', got {spec!r}.")
+    node_id, handle = spec.split(".", 1)
+    if not node_id or not handle:
+        raise click.ClickException(f"Expected 'nodeId.handle', got {spec!r}.")
+    return node_id, handle
+
+
 @workflow.command("check")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @config_option
@@ -437,6 +464,209 @@ def workflow_init(path: Path, force: bool):
     else:
         path.write_text(json.dumps(blank, indent=2) + "\n")
     click.echo(f"Wrote blank workflow to {path}")
+
+
+# ---------- workflow edit ----------
+
+
+@workflow.group("edit")
+def workflow_edit():
+    """Edit a workflow file in-place. Each edit re-validates and only saves on success."""
+
+
+@workflow_edit.command("add-node")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("name")
+@click.argument("node_id", metavar="ID")
+@click.argument("params_arg", metavar="PARAMS", default="{}")
+@config_option
+@coro
+async def edit_add_node(
+    path: Path,
+    name: str,
+    node_id: str,
+    params_arg: str,
+    config_path: Path | None,
+):
+    """Append a new node to inner_nodes."""
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    if node_id in wf.nodes_by_id:
+        raise click.ClickException(f"Node id {node_id!r} already exists in workflow.")
+    params = _load_input(params_arg)
+    new_node = engine.create_node(name, id=node_id, params=params)
+    new_wf = wf.model_copy(update={"inner_nodes": (*wf.inner_nodes, new_node)})
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Added node {node_id!r} ({name}).")
+
+
+@workflow_edit.command("remove-node")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("node_id", metavar="ID")
+@config_option
+@coro
+async def edit_remove_node(path: Path, node_id: str, config_path: Path | None):
+    """Remove an inner node and any edges that touch it."""
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    if node_id == wf.input_node.id or node_id == wf.output_node.id:
+        raise click.ClickException(
+            f"Cannot remove the workflow's input/output node ({node_id!r})."
+        )
+    if node_id not in wf.nodes_by_id:
+        raise click.ClickException(f"Node id {node_id!r} not found.")
+    new_inner = tuple(n for n in wf.inner_nodes if n.id != node_id)
+    new_edges = tuple(
+        e for e in wf.edges if e.source_id != node_id and e.target_id != node_id
+    )
+    dropped_edges = len(wf.edges) - len(new_edges)
+    new_wf = wf.model_copy(update={"inner_nodes": new_inner, "edges": new_edges})
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Removed node {node_id!r} and {dropped_edges} associated edge(s).")
+
+
+@workflow_edit.command("add-edge")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("source")
+@click.argument("target")
+@config_option
+@coro
+async def edit_add_edge(path: Path, source: str, target: str, config_path: Path | None):
+    """Add an edge SOURCE -> TARGET (each formatted as 'nodeId.handle')."""
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    src_id, src_key = _parse_handle(source)
+    tgt_id, tgt_key = _parse_handle(target)
+    new_edge = Edge(
+        source_id=src_id,
+        source_key=src_key,
+        target_id=tgt_id,
+        target_key=tgt_key,
+    )
+    new_wf = wf.model_copy(update={"edges": (*wf.edges, new_edge)})
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Added edge {source} -> {target}.")
+
+
+@workflow_edit.command("remove-edge")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("source")
+@click.argument("target")
+@config_option
+@coro
+async def edit_remove_edge(
+    path: Path, source: str, target: str, config_path: Path | None
+):
+    """Remove the edge SOURCE -> TARGET."""
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    src_id, src_key = _parse_handle(source)
+    tgt_id, tgt_key = _parse_handle(target)
+
+    def matches(e: Edge) -> bool:
+        return (
+            e.source_id == src_id
+            and ".".join(e.source_key_path) == src_key
+            and e.target_id == tgt_id
+            and e.target_key == tgt_key
+        )
+
+    new_edges = tuple(e for e in wf.edges if not matches(e))
+    if len(new_edges) == len(wf.edges):
+        raise click.ClickException(f"Edge {source} -> {target} not found.")
+    new_wf = wf.model_copy(update={"edges": new_edges})
+    await _validate_or_die(engine, new_wf)
+    _save_workflow(path, new_wf)
+    click.echo(f"Removed edge {source} -> {target}.")
+
+
+@workflow_edit.command("possible-edges")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("handle")
+@config_option
+@coro
+async def edit_possible_edges(path: Path, handle: str, config_path: Path | None):
+    """For HANDLE (nodeId.handle), list compatible counterparts.
+
+    If the handle is a node output, lists target inputs it can connect to.
+    If it's an input, lists source outputs that can connect to it.
+    Already-wired inputs are excluded (each input takes one source).
+    """
+    engine = await _build_engine(config_path)
+    wf = _load_workflow(path)
+    validated = await engine.validate(wf)
+
+    node_id, key = _parse_handle(handle)
+    if node_id not in validated.nodes_by_id:
+        raise click.ClickException(f"Unknown node id: {node_id}")
+
+    out_t = validated.node_output_types.get(node_id)
+    in_t = validated.node_input_types.get(node_id)
+    is_output = out_t is not None and key in out_t.model_fields
+    is_input = in_t is not None and key in in_t.model_fields
+
+    if not is_output and not is_input:
+        raise click.ClickException(
+            f"Node {node_id!r} has no handle {key!r} on its input or output."
+        )
+
+    def field_value_cls(data_cls, field_name: str) -> type[Value] | None:
+        ann = data_cls.model_fields[field_name].annotation
+        return ann if isinstance(ann, type) and issubclass(ann, Value) else None
+
+    wired_inputs = {(e.target_id, e.target_key) for e in wf.edges}
+    matches: list[str] = []
+
+    if is_output:
+        src_cls = field_value_cls(out_t, key)
+        if src_cls is None:
+            raise click.ClickException(
+                f"Output handle {handle!r} has a non-Value annotation; can't compute compatibility."
+            )
+        for other_id, other_in_t in validated.node_input_types.items():
+            if other_id == node_id:
+                continue
+            for fname in other_in_t.model_fields:
+                if (other_id, fname) in wired_inputs:
+                    continue
+                tgt_cls = field_value_cls(other_in_t, fname)
+                if tgt_cls is None:
+                    continue
+                try:
+                    if src_cls.can_cast_to(tgt_cls):
+                        matches.append(f"{other_id}.{fname}")
+                except Exception:
+                    pass
+    else:
+        # is_input
+        if (node_id, key) in wired_inputs:
+            click.echo(
+                f"# {handle} already has an incoming edge; remove it first to rewire.",
+                err=True,
+            )
+        tgt_cls = field_value_cls(in_t, key)
+        if tgt_cls is None:
+            raise click.ClickException(
+                f"Input handle {handle!r} has a non-Value annotation; can't compute compatibility."
+            )
+        for other_id, other_out_t in validated.node_output_types.items():
+            if other_id == node_id:
+                continue
+            for fname in other_out_t.model_fields:
+                src_cls = field_value_cls(other_out_t, fname)
+                if src_cls is None:
+                    continue
+                try:
+                    if src_cls.can_cast_to(tgt_cls):
+                        matches.append(f"{other_id}.{fname}")
+                except Exception:
+                    pass
+
+    for m in matches:
+        click.echo(m)
 
 
 def main():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -618,20 +618,19 @@ class TestWorkflowEdit:
             "--config",
             str(config_path),
         )
-        # Adding another sibling node — its values input shouldn't appear because... well
-        # actually it would appear since it's unwired. Test the simpler case:
-        # summer.sum's matches should still include output.total since output.total is unwired.
+        # input.nums (an output handle) is now wired into summer.values; that
+        # already-wired target should NOT appear in its candidate list anymore.
         out = _run(
             runner,
             "workflow",
             "edit",
             "possible-edges",
             str(populated_workflow),
-            "summer.sum",
+            "input.nums",
             "--config",
             str(config_path),
         )
-        assert "output.total" in out
+        assert "summer.values" not in out
 
     def test_full_construction_then_run(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -778,3 +778,149 @@ class TestWorkflowEdit:
         payload = json.loads(populated_workflow.read_text())
         ids = [n["id"] for n in payload["inner_nodes"]]
         assert ids == ["summer"]
+
+    def test_add_field_to_input(
+        self, runner: CliRunner, config_path: Path, tmp_path: Path
+    ):
+        wf = tmp_path / "wf.json"
+        _run(runner, "workflow", "init", str(wf))
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-field",
+            str(wf),
+            "input.x",
+            '{"x-value-type": "IntegerValue"}',
+            "--config",
+            str(config_path),
+        )
+        payload = json.loads(wf.read_text())
+        assert payload["input_node"]["params"]["fields"] == {
+            "x": {"x-value-type": "IntegerValue"}
+        }
+
+    def test_add_field_rejects_duplicate(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "add-field",
+                str(populated_workflow),
+                "input.nums",
+                '{"x-value-type": "IntegerValue"}',
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_update_field_replaces_schema(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "update-field",
+            str(populated_workflow),
+            "input.nums",
+            '{"x-value-type": "IntegerValue"}',
+            "--config",
+            str(config_path),
+        )
+        payload = json.loads(populated_workflow.read_text())
+        assert payload["input_node"]["params"]["fields"]["nums"] == {
+            "x-value-type": "IntegerValue"
+        }
+
+    def test_update_field_rejects_unknown(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "update-field",
+                str(populated_workflow),
+                "input.ghost",
+                '{"x-value-type": "IntegerValue"}',
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_remove_field_drops_referencing_edges(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        out = _run(
+            runner,
+            "workflow",
+            "edit",
+            "remove-field",
+            str(populated_workflow),
+            "input.nums",
+            "--config",
+            str(config_path),
+        )
+        assert "1 associated edge" in out
+        payload = json.loads(populated_workflow.read_text())
+        assert payload["edges"] == []
+        assert payload["input_node"]["params"]["fields"] == {}
+
+    def test_field_commands_reject_inner_node(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "add-field",
+                str(populated_workflow),
+                "summer.foo",
+                '{"x-value-type": "IntegerValue"}',
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "input or output" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,3 +324,365 @@ class TestWorkflow:
         )
         payload = json.loads(out)
         assert payload["output"] == {"total": 8.0}
+
+
+# ---------- workflow edit ----------
+
+
+@pytest.fixture
+def populated_workflow(tmp_path: Path) -> Path:
+    """A workflow with input.nums:array<FloatValue> and output.total:FloatValue, no inner nodes."""
+    path = tmp_path / "wf.json"
+    path.write_text(
+        json.dumps(
+            {
+                "input_node": {
+                    "type": "Input",
+                    "id": "input",
+                    "params": {
+                        "fields": {
+                            "nums": {
+                                "type": "array",
+                                "items": {"x-value-type": "FloatValue"},
+                            }
+                        }
+                    },
+                },
+                "output_node": {
+                    "type": "Output",
+                    "id": "output",
+                    "params": {"fields": {"total": {"x-value-type": "FloatValue"}}},
+                },
+                "inner_nodes": [],
+                "edges": [],
+            }
+        )
+    )
+    return path
+
+
+class TestWorkflowEdit:
+    def test_add_node_appends_to_inner_nodes(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        payload = json.loads(populated_workflow.read_text())
+        assert [n["id"] for n in payload["inner_nodes"]] == ["summer"]
+        assert payload["inner_nodes"][0]["type"] == "Sum"
+
+    def test_add_node_rejects_duplicate_id(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "add-node",
+                str(populated_workflow),
+                "Sum",
+                "input",  # collides with InputNode id
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_remove_node_drops_associated_edges(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        out = _run(
+            runner,
+            "workflow",
+            "edit",
+            "remove-node",
+            str(populated_workflow),
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        assert "1 associated edge" in out
+        payload = json.loads(populated_workflow.read_text())
+        assert payload["inner_nodes"] == []
+        assert payload["edges"] == []
+
+    def test_remove_node_refuses_to_remove_input_or_output(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        for nid in ("input", "output"):
+            result = runner.invoke(
+                cli,
+                [
+                    "workflow",
+                    "edit",
+                    "remove-node",
+                    str(populated_workflow),
+                    nid,
+                    "--config",
+                    str(config_path),
+                ],
+            )
+            assert result.exit_code != 0
+
+    def test_add_edge_validates_types(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        # Wrong direction: SequenceValue[FloatValue] cannot cast to FloatValue
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "add-edge",
+                str(populated_workflow),
+                "input.nums",
+                "output.total",
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+        # And the file should be untouched
+        payload = json.loads(populated_workflow.read_text())
+        assert payload["edges"] == []
+
+    def test_remove_edge_works_and_errors_when_missing(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "remove-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        # Removing again should fail
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "remove-edge",
+                str(populated_workflow),
+                "input.nums",
+                "summer.values",
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_possible_edges_finds_compatible_input(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        out = _run(
+            runner,
+            "workflow",
+            "edit",
+            "possible-edges",
+            str(populated_workflow),
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        assert "input.nums" in out
+
+    def test_possible_edges_finds_compatible_output(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        out = _run(
+            runner,
+            "workflow",
+            "edit",
+            "possible-edges",
+            str(populated_workflow),
+            "summer.sum",
+            "--config",
+            str(config_path),
+        )
+        assert "output.total" in out
+
+    def test_possible_edges_excludes_already_wired(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        # Adding another sibling node — its values input shouldn't appear because... well
+        # actually it would appear since it's unwired. Test the simpler case:
+        # summer.sum's matches should still include output.total since output.total is unwired.
+        out = _run(
+            runner,
+            "workflow",
+            "edit",
+            "possible-edges",
+            str(populated_workflow),
+            "summer.sum",
+            "--config",
+            str(config_path),
+        )
+        assert "output.total" in out
+
+    def test_full_construction_then_run(
+        self,
+        runner: CliRunner,
+        config_path: Path,
+        populated_workflow: Path,
+        base_dir: Path,
+    ):
+        # Build a Sum-pipeline by editing and run it.
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "summer.sum",
+            "output.total",
+            "--config",
+            str(config_path),
+        )
+        out = _run(
+            runner,
+            "workflow",
+            "run",
+            str(populated_workflow),
+            '{"nums": [10.0, 20.0, 30.0]}',
+            "--config",
+            str(config_path),
+            "--base-dir",
+            str(base_dir),
+        )
+        assert json.loads(out)["output"] == {"total": 60.0}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -686,3 +686,95 @@ class TestWorkflowEdit:
             str(base_dir),
         )
         assert json.loads(out)["output"] == {"total": 60.0}
+
+    def test_update_node_modifies_input_fields(
+        self, runner: CliRunner, config_path: Path, tmp_path: Path
+    ):
+        wf = tmp_path / "wf.json"
+        _run(runner, "workflow", "init", str(wf))
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "update-node",
+            str(wf),
+            "input",
+            '{"fields": {"x": {"x-value-type": "IntegerValue"}}}',
+            "--config",
+            str(config_path),
+        )
+        payload = json.loads(wf.read_text())
+        assert payload["input_node"]["params"]["fields"] == {
+            "x": {"x-value-type": "IntegerValue"}
+        }
+
+    def test_update_node_unknown_id_errors(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "update-node",
+                str(populated_workflow),
+                "ghost",
+                "{}",
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_update_node_bad_params_reports_clean_error(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        before = populated_workflow.read_text()
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "update-node",
+                str(populated_workflow),
+                "input",
+                '{"fields": "not a dict"}',
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        # File should be untouched
+        assert populated_workflow.read_text() == before
+
+    def test_update_node_preserves_inner_node_id(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        # Only relevant to test inner-node update path (different from input/output)
+        # Sum has Empty params, so update with {} keeps it valid.
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "update-node",
+            str(populated_workflow),
+            "summer",
+            "{}",
+            "--config",
+            str(config_path),
+        )
+        payload = json.loads(populated_workflow.read_text())
+        ids = [n["id"] for n in payload["inner_nodes"]]
+        assert ids == ["summer"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -924,3 +924,106 @@ class TestWorkflowEdit:
         )
         assert result.exit_code != 0
         assert "input or output" in result.output
+
+    def test_update_field_drops_now_incompatible_edge(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        # Wire a Sum that consumes input.nums (FloatValue array).
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "summer.sum",
+            "output.total",
+            "--config",
+            str(config_path),
+        )
+        # Now break input.nums type — its edge to summer.values should be dropped.
+        result = runner.invoke(
+            cli,
+            [
+                "workflow",
+                "edit",
+                "update-field",
+                str(populated_workflow),
+                "input.nums",
+                '{"x-value-type": "IntegerValue"}',
+                "--config",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # ClickException sends warnings to stderr, but CliRunner combines them by default.
+        # Check via mix_stderr or by reading workflow state.
+        payload = json.loads(populated_workflow.read_text())
+        edge_pairs = {
+            (e["source_id"], e["source_key"], e["target_id"], e["target_key"])
+            for e in payload["edges"]
+        }
+        assert ("input", "nums", "summer", "values") not in edge_pairs
+        assert ("summer", "sum", "output", "total") in edge_pairs
+
+    def test_update_node_drops_now_incompatible_edge(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        # Same as above but use update-node on the input node.
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-node",
+            str(populated_workflow),
+            "Sum",
+            "summer",
+            "--config",
+            str(config_path),
+        )
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "add-edge",
+            str(populated_workflow),
+            "input.nums",
+            "summer.values",
+            "--config",
+            str(config_path),
+        )
+        # Replace input's fields entirely with an IntegerValue 'nums'.
+        _run(
+            runner,
+            "workflow",
+            "edit",
+            "update-node",
+            str(populated_workflow),
+            "input",
+            '{"fields": {"nums": {"x-value-type": "IntegerValue"}}}',
+            "--config",
+            str(config_path),
+        )
+        payload = json.loads(populated_workflow.read_text())
+        assert payload["edges"] == []


### PR DESCRIPTION
## Summary
- Implements the deferred `wengine workflow edit` subgroup from `docs/cli.md`:
  - `add-node <name> <id> [params]`
  - `remove-node <id>` — also drops all edges that touch the node
  - `add-edge <source> <target>`
  - `remove-edge <source> <target>`
  - `possible-edges <nodeId>.<handle>` — lists compatible counterparts using `Value.can_cast_to` (mirrors the type-compatibility logic from python-backend)
- Each edit reloads the file, applies the change, runs full `engine.validate(...)`, and only writes back on success — failures leave the file untouched.
- Validation errors are wrapped in `ClickException` so the CLI never leaks a Python traceback.

End-to-end builds work: starting from `workflow init`, an agent (or user) can fully assemble a Sum pipeline via `add-node` + `add-edge` and then `workflow run` it.

## Test plan
- [x] `uv run pytest` — 478 passed, 1 xfailed
- [x] 10 new tests in `tests/test_cli.py::TestWorkflowEdit` cover the happy paths, type-validation rejection, double-removal errors, refusal to remove input/output nodes, and a full init → edit → run round-trip
- [x] Manual smoke test: built, ran, and rewired a Sum workflow end-to-end via the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)