### PR TITLE
Compact schemas, richer node list, Input/Output guard

### DIFF
--- a/.claude/skills/wengine/SKILL.md
+++ b/.claude/skills/wengine/SKILL.md
@@ -87,13 +87,18 @@ Two implications for agents:
 - `wengine workflow edit possible-edges` **already includes castable matches**, not just exact-type matches. If a target appears in the list, the edge is wireable as-is.
 - If `add-edge` rejects an edge with a "not assignable to" error, no cast path exists between those types. You need an intermediate node that bridges them, or a different source field. `possible-edges` from the *target* side will tell you which sources are reachable.
 
-## Reading expanded schemas
+## Reading schemas
 
-`wengine schema check`, `node check`, and `workflow check` emit **fully-expanded** JSON schemas. To decode them:
+`node check`, `workflow check`, and `workflow describe --json` emit a **compact** JSON schema by default. Sub-schemas for concrete `Value` types collapse to `{"x-value-type": "<Name>"}`, generics keep their JSON Schema shape with `x-value-type` on the inner Value, and there are no `$defs` to chase. This is the form to read.
 
-- The top-level `title` is the synthesized class name (e.g. `SumNodeInput`) — descriptive, not addressable.
-- Each property uses `$ref` into `$defs`. Look up the def's **`title`** (e.g. `"SequenceValue[FloatValue]"`) for the canonical Value type — `$defs` keys are mangled and not user-facing.
+Pass `--expanded` to any of those commands to get the full Pydantic schema (`$defs`, `$ref`, structural titles) when you need a strict JSON Schema for an external validator.
+
+`schema check` is the one exception: it always emits the expanded form, because its purpose is to demystify a compact `x-value-type` blob into its concrete shape.
+
+When reading either form:
 - `required` lists mandatory fields; `additionalProperties: false` rejects extras.
+- In the compact form, each property carries its `title`/`description` directly.
+- In the expanded form, follow each property's `$ref` into `$defs` and read the def's `title` (e.g. `"SequenceValue[FloatValue]"`) for the canonical Value type. `$defs` keys are mangled identifiers — read the title, not the key.
 
 To validate a value against a schema: `wengine schema parse <schema> <value>`.
 
@@ -114,7 +119,13 @@ wengine node run Sum '{}' '{"values": [1.5, 2.5, 4.0]}'
 # prints {"sum": 8.0} and writes intermediate files under ./local/<uuid>/
 ```
 
-When exploring, **call `wengine node check <Name>` first** to learn the exact input/output schemas before running.
+#### Discovering nodes and their shapes
+
+Before running, three commands make a node legible:
+
+- `wengine node list` — every registered node with its alias, display name, and description (one row per node). The first column is the alias to use everywhere else.
+- `wengine node info <Name>` — full metadata for one node: display name, description, version, and the **parameter schema** (what goes in the `<params>` argument). Read this *first* whenever you need to construct params.
+- `wengine node check <Name> <params>` — validates the node with concrete params and prints its **resolved input and output schemas** (compact form by default). This is critical for nodes whose I/O shape is dynamic — e.g. variadic `Add`, where setting `num_arguments=3` causes input fields `a`, `b`, `c` to appear. Always run `node check` after settling on params and before constructing inputs.
 
 ### 2. Compose: build a saved workflow
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,7 +130,7 @@ When a schema-changing edit (`update-node` or `update-field`) makes an existing 
 
 #### `wengine workflow edit add-node <path> <name> <id> [params]`
 
-Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is a JSON literal, `@file.json`, or `-` for stdin (defaults to `{}`).
+Append a new node of type `<name>` with id `<id>` to `inner_nodes`. `params` is a JSON literal, `@file.json`, or `-` for stdin (defaults to `{}`). Rejects `Input`/`Output` node types — every workflow has exactly one of each, so they can't be added as inner nodes; use `update-node` / `add-field` / `update-field` to modify the existing ones.
 
 #### `wengine workflow edit update-node <path> <id> <params>`
 

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -22,7 +22,6 @@ from workflow_engine.core.config import WorkflowEngineConfig
 from workflow_engine.core.context import ValidationContext
 from workflow_engine.core.edge import Edge
 from workflow_engine.core.engine import WorkflowEngine
-from workflow_engine.core.io import InputNode, OutputNode
 from workflow_engine.core.node import NodeRegistry
 from workflow_engine.core.values import ValueRegistry
 from workflow_engine.core.values.data import Data, DataValue
@@ -629,11 +628,10 @@ async def edit_add_node(
     wf = _load_workflow(path)
     if node_id in wf.nodes_by_id:
         raise click.ClickException(f"Node id {node_id!r} already exists in workflow.")
-    cls = engine.node_registry.get(name)
-    if cls is not None and issubclass(cls, (InputNode, OutputNode)):
+    if name in ("Input", "Output"):
         raise click.ClickException(
-            f"Cannot add an Input/Output-type node ({name!r}) as an inner node. "
-            f"Each workflow already has exactly one input and one output node — "
+            f"Cannot add the {name!r} node as an inner node. "
+            f"Every workflow has exactly one Input and one Output node — "
             f"use `update-node`, `add-field`, or `update-field` to modify them."
         )
     params = _load_input(params_arg)

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -22,10 +22,14 @@ from workflow_engine.core.config import WorkflowEngineConfig
 from workflow_engine.core.context import ValidationContext
 from workflow_engine.core.edge import Edge
 from workflow_engine.core.engine import WorkflowEngine
+from workflow_engine.core.io import InputNode, OutputNode
 from workflow_engine.core.node import NodeRegistry
 from workflow_engine.core.values import ValueRegistry
+from workflow_engine.core.values.data import Data, DataValue
+from workflow_engine.core.values.mapping import StringMapValue
 from workflow_engine.core.values.schema import validate_value_schema
-from workflow_engine.core.values.value import Value
+from workflow_engine.core.values.sequence import SequenceValue
+from workflow_engine.core.values.value import Value, get_origin_and_args
 from workflow_engine.core.workflow import Workflow
 
 CONFIG_DIR = Path(platformdirs.user_config_dir("wengine", appauthor=False))
@@ -63,6 +67,59 @@ def _load_input(value: str) -> Any:
         return json.loads(text)
     except json.JSONDecodeError as e:
         raise click.ClickException(f"Invalid JSON in {source}: {e}") from e
+
+
+def _compact_value_schema(value_cls: type[Value]) -> dict[str, Any]:
+    """Render a Value subclass as a compact `x-value-type`-shaped schema.
+
+    Concrete types serialize as `{"x-value-type": "<Name>"}`. Generic
+    composites unfold into the standard JSON Schema shape (`type: array`,
+    `type: object` with `additionalProperties`, or full Data layout) with
+    `x-value-type` on the inner Value(s).
+    """
+    origin, args = get_origin_and_args(value_cls)
+    if not args:
+        return {"x-value-type": origin.__name__}
+    if issubclass(origin, SequenceValue):
+        return {"type": "array", "items": _compact_value_schema(args[0])}
+    if issubclass(origin, StringMapValue):
+        return {
+            "type": "object",
+            "additionalProperties": _compact_value_schema(args[0]),
+        }
+    if issubclass(origin, DataValue):
+        inner = args[0]
+        if isinstance(inner, type) and issubclass(inner, Data):
+            return _compact_data_schema(inner)
+    # Unknown generic — fall back to the registered name.
+    return {"x-value-type": value_cls.__name__}
+
+
+def _compact_data_schema(data_cls: type[Data]) -> dict[str, Any]:
+    """Render a Data subclass as a compact object schema."""
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, info in data_cls.model_fields.items():
+        ann = info.annotation
+        if isinstance(ann, type) and issubclass(ann, Value):
+            prop = _compact_value_schema(ann)
+        else:
+            prop = {"description": f"<unrepresentable annotation: {ann!r}>"}
+        if info.title:
+            prop["title"] = info.title
+        if info.description:
+            prop["description"] = info.description
+        properties[name] = prop
+        if info.is_required():
+            required.append(name)
+    out: dict[str, Any] = {
+        "type": "object",
+        "title": data_cls.__name__,
+        "properties": properties,
+    }
+    if required:
+        out["required"] = required
+    return out
 
 
 async def _build_engine(config_path: Path | None) -> WorkflowEngine:
@@ -141,12 +198,17 @@ async def schema_list(config_path: Path | None):
 @config_option
 @coro
 async def schema_check(schema_arg: str, config_path: Path | None):
-    """Validate an aliased value schema and print the fully-resolved schema.
+    """Validate an aliased value schema and print the fully-expanded JSON schema.
 
     SCHEMA is a JSON literal, @file.json, or - for stdin. Examples:
 
       wengine schema check '{"x-value-type": "JSONValue"}'
       wengine schema check '{"type": "array", "items": {"x-value-type": "StringValue"}}'
+
+    The output is the full Pydantic JSON schema with `$defs`/`$ref` — useful
+    for demystifying a compact `x-value-type` blob into its concrete shape.
+    The other `check` commands (`node`, `workflow`) default to the compact
+    form because their inputs are typed nodes/workflows, not raw schemas.
     """
     # Building the engine surfaces config errors early; schema resolution
     # itself still uses ValueRegistry.DEFAULT today.
@@ -185,12 +247,21 @@ def node():
 @config_option
 @coro
 async def node_list(config_path: Path | None):
-    """List registered node types."""
+    """List registered node types with their display names and descriptions.
+
+    For full per-node metadata (version, parameter schema), use `node info <name>`.
+    """
     engine = await _build_engine(config_path)
+    rows: list[tuple[str, str, str]] = []
     for name, cls in engine.node_registry.items():
         info = getattr(cls, "TYPE_INFO", None)
         display = getattr(info, "display_name", name) if info else name
-        click.echo(f"{name}\t{display}")
+        description = (getattr(info, "description", None) if info else None) or ""
+        rows.append((name, display, description))
+    name_w = max((len(r[0]) for r in rows), default=0)
+    display_w = max((len(r[1]) for r in rows), default=0)
+    for name, display, description in rows:
+        click.echo(f"{name:<{name_w}}  {display:<{display_w}}  {description}".rstrip())
 
 
 @node.command("info")
@@ -221,10 +292,17 @@ async def node_info(name: str, config_path: Path | None):
 @node.command("check")
 @click.argument("name")
 @click.argument("params_arg", metavar="PARAMS", default="{}")
+@click.option(
+    "--expanded",
+    is_flag=True,
+    help="Emit full Pydantic JSON schemas with $defs/$ref instead of the compact x-value-type form.",
+)
 @config_option
 @coro
-async def node_check(name: str, params_arg: str, config_path: Path | None):
-    """Validate a node and print its input and output JSON schemas."""
+async def node_check(
+    name: str, params_arg: str, expanded: bool, config_path: Path | None
+):
+    """Validate a node and print its input and output schemas."""
     engine = await _build_engine(config_path)
     params = _load_input(params_arg)
     instance = engine.create_node(name, id="check", params=params)
@@ -234,13 +312,15 @@ async def node_check(name: str, params_arg: str, config_path: Path | None):
     )
     in_t = await instance.input_type(ctx)
     out_t = await instance.output_type(ctx)
+    if expanded:
+        in_s = in_t.model_json_schema()
+        out_s = out_t.model_json_schema()
+    else:
+        in_s = _compact_data_schema(in_t)
+        out_s = _compact_data_schema(out_t)
     click.echo(
         json.dumps(
-            {
-                "ok": True,
-                "input_schema": in_t.model_json_schema(),
-                "output_schema": out_t.model_json_schema(),
-            },
+            {"ok": True, "input_schema": in_s, "output_schema": out_s},
             indent=2,
             default=str,
         )
@@ -387,19 +467,31 @@ def _parse_handle(spec: str) -> tuple[str, str]:
 
 @workflow.command("check")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--expanded",
+    is_flag=True,
+    help="Emit full Pydantic JSON schemas with $defs/$ref instead of the compact x-value-type form.",
+)
 @config_option
 @coro
-async def workflow_check(path: Path, config_path: Path | None):
+async def workflow_check(path: Path, expanded: bool, config_path: Path | None):
     """Validate a workflow and print its input/output schemas."""
     engine = await _build_engine(config_path)
     wf = _load_workflow(path)
     validated = await _validate_or_die(engine, wf)
-    out = {
-        "ok": True,
-        "input_schema": validated.input_type.model_json_schema(),
-        "output_schema": validated.output_type.model_json_schema(),
-    }
-    click.echo(json.dumps(out, indent=2, default=str))
+    if expanded:
+        in_s = validated.input_type.model_json_schema()
+        out_s = validated.output_type.model_json_schema()
+    else:
+        in_s = _compact_data_schema(validated.input_type)
+        out_s = _compact_data_schema(validated.output_type)
+    click.echo(
+        json.dumps(
+            {"ok": True, "input_schema": in_s, "output_schema": out_s},
+            indent=2,
+            default=str,
+        )
+    )
 
 
 @workflow.command("run")
@@ -462,8 +554,8 @@ async def workflow_describe(path: Path, as_json: bool, config_path: Path | None)
     summary: dict[str, Any] = {
         "nodes": nodes_summary,
         "edges": edges_summary,
-        "input_schema": validated.input_type.model_json_schema(),
-        "output_schema": validated.output_type.model_json_schema(),
+        "input_schema": _compact_data_schema(validated.input_type),
+        "output_schema": _compact_data_schema(validated.output_type),
         "execution_order": groups,
     }
 
@@ -537,6 +629,13 @@ async def edit_add_node(
     wf = _load_workflow(path)
     if node_id in wf.nodes_by_id:
         raise click.ClickException(f"Node id {node_id!r} already exists in workflow.")
+    cls = engine.node_registry.get(name)
+    if cls is not None and issubclass(cls, (InputNode, OutputNode)):
+        raise click.ClickException(
+            f"Cannot add an Input/Output-type node ({name!r}) as an inner node. "
+            f"Each workflow already has exactly one input and one output node — "
+            f"use `update-node`, `add-field`, or `update-field` to modify them."
+        )
     params = _load_input(params_arg)
     try:
         new_node = engine.create_node(name, id=node_id, params=params)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,10 @@ class TestSchema:
     def test_check_resolves_concrete(self, runner: CliRunner):
         out = _run(runner, "schema", "check", '{"x-value-type": "JSONValue"}')
         payload = json.loads(out)
+        # `schema check` always emits the expanded form — its purpose is to
+        # demystify the compact x-value-type input.
         assert payload["title"] == "JSONValue"
+        assert "$defs" in payload
 
     def test_check_resolves_generic(self, runner: CliRunner):
         out = _run(
@@ -138,8 +141,11 @@ class TestSchema:
 class TestNode:
     def test_list_uses_config(self, runner: CliRunner, config_path: Path):
         out = _run(runner, "node", "list", "--config", str(config_path))
-        names = {line.split("\t", 1)[0] for line in out.strip().splitlines()}
+        # Each line: "<name>  <display>  <description>" — name is the first token.
+        names = {line.split()[0] for line in out.strip().splitlines() if line.strip()}
         assert {"Input", "Output", "Sum"} == names
+        # Description should be present for built-in nodes.
+        assert "Sums a sequence of numbers." in out
 
     def test_info_returns_metadata(self, runner: CliRunner, config_path: Path):
         out = _run(runner, "node", "info", "Sum", "--config", str(config_path))
@@ -397,6 +403,26 @@ class TestWorkflowEdit:
             ],
         )
         assert result.exit_code != 0
+
+    def test_add_node_rejects_input_or_output_types(
+        self, runner: CliRunner, config_path: Path, populated_workflow: Path
+    ):
+        for type_name in ("Input", "Output"):
+            result = runner.invoke(
+                cli,
+                [
+                    "workflow",
+                    "edit",
+                    "add-node",
+                    str(populated_workflow),
+                    type_name,
+                    f"second-{type_name.lower()}",
+                    "--config",
+                    str(config_path),
+                ],
+            )
+            assert result.exit_code != 0
+            assert "inner node" in result.output
 
     def test_remove_node_drops_associated_edges(
         self, runner: CliRunner, config_path: Path, populated_workflow: Path


### PR DESCRIPTION
## Summary

Several rough edges surfaced while dogfooding the \`wengine\` skill on a real workflow-building task. This PR addresses them.

- **Compact schemas by default.** \`node check\`, \`workflow check\`, and \`workflow describe --json\` previously emitted the full Pydantic JSON schema with \`\$defs\`/\`\$ref\` — readable but very verbose. They now emit a compact form: concrete Value types collapse to \`{"x-value-type": "<Name>"}\`, generics keep their JSON Schema shape with \`x-value-type\` on the inner Value, and there are no \`\$defs\` to chase. Pass \`--expanded\` for the old form when you need a strict JSON Schema for an external validator. \`schema check\` is unchanged — its job is to demystify the compact input, so it stays expanded.
- **\`node list\` includes descriptions.** Output is now \`<alias>  <display>  <description>\` columns, so the descriptions registered on each node are visible without an extra \`node info\` call. (\`node info\` is still the way to get the parameter schema.)
- **Reject Input/Output as inner nodes.** \`workflow edit add-node\` now refuses node types that subclass \`InputNode\`/\`OutputNode\`. Every workflow has exactly one of each, modified via \`update-node\` / \`add-field\` / \`update-field\`.
- **SKILL.md** updated to reflect the compact-schema default, surface the node-discovery commands (\`node list\` / \`node info\` / \`node check\`) more prominently, and explain when each is the right tool.

## Test plan
- [x] \`uv run pytest\` — 47 CLI tests pass (1 new test for Input/Output rejection, 1 updated for the new \`node list\` format, schema-check tests adjusted)
- [x] Smoke-tested the 3^10 workflow build end-to-end against the new compact schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)