### PR TITLE
Add POSIX wengine skill shim under scripts/ and wire releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ To cut a new release:
 
 1. **Update `CHANGELOG.md`** — study the commits since the last release tag (`git log <last-tag>..HEAD`), then add a new section at the top (after the header) with the new version, date, and a human-readable summary of what changed. Group entries under `### Added`, `### Changed`, and/or `### Fixed` as appropriate. Follow the existing format.
 
-2. **Run the release script** — must be on a clean, up-to-date `main` branch. The script bumps the version in `pyproject.toml`, `src/workflow_engine/__init__.py`, and `plugins/wengine/.claude-plugin/plugin.json` (the wengine skill plugin version is locked to the library version), then runs the full check suite (tests, ruff check, ruff format, pyright) before committing, tagging, pushing, and creating a GitHub release:
+2. **Run the release script** — must be on a clean, up-to-date `main` branch. The script bumps the version in `pyproject.toml`, `src/workflow_engine/__init__.py`, `plugins/wengine/.claude-plugin/plugin.json`, and the pinned version inside `plugins/wengine/skills/wengine/scripts/wengine.sh` (the wengine skill plugin and shim stay locked to the library version), then runs the full check suite (tests, ruff check, ruff format, pyright) before committing, tagging, pushing, and creating a GitHub release:
 
    ```bash
    ./release.sh --rc      # bump release candidate: 2.0.0rc4 -> 2.0.0rc5

--- a/plugins/wengine/skills/wengine/SKILL.md
+++ b/plugins/wengine/skills/wengine/SKILL.md
@@ -7,13 +7,35 @@ description: Use the `wengine` CLI to explore, compose, validate, and run typed 
 
 `wengine` is a CLI for `aceteam-workflow-engine`. It lets you (a) execute single nodes for ad-hoc work, (b) build and validate DAGs of nodes ("workflows") with full type checking, and (c) run those workflows against typed inputs.
 
+## Bundled script
+
+This skill bundles a POSIX `sh` launcher that bootstraps `uv` (if needed), installs the pinned `aceteam-workflow-engine` wheel under `~/.wengine/runtime`, and runs the real CLI. You do not need a global `pip install` or `wengine` on `PATH`.
+
+Per the [agentskills.io convention for scripts](https://agentskills.io/skill-creation/using-scripts), paths are **relative to this skill directory** (the folder that contains `SKILL.md`). The agent should run commands from that directory.
+
+| Script                   | Role                                                                                                |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| **`scripts/wengine.sh`** | CLI entrypoint; pass the same arguments you would pass to `wengine` (subcommands, flags, `--help`). |
+
+Example:
+
+```sh
+sh scripts/wengine.sh --help
+sh scripts/wengine.sh config path
+```
+
+If the environment already has `wengine` on `PATH` from a normal install, you may use `wengine` directly instead of `sh scripts/wengine.sh` in the examples below.
+
 ## Invoking this skill
 
 This is a playbook, not a parameterized template. The user supplies the task in plain language ("use the wengine skill to prototype a workflow that scrapes pricing data from these URLs"), and you carry it out by following the steps below — substituting the user's goal for the abstract task. You don't need to ask for arguments; pull every concrete detail you need from the user prompt and the surrounding context.
 
+Throughout this document, **`wengine`** in command examples means the CLI itself—use `sh scripts/wengine.sh` from the skill directory when no global `wengine` is available (the common case for agents).
+
 ## The agent loop
 
 The standard agent loop is:
+
 1. **Explore** with `wengine node run <Name> <params> <input>` to learn what each node produces on real data, writing artifacts to disk that the next node can consume.
 2. **Compose** with `wengine workflow init` + `wengine workflow edit ...` to assemble a saved workflow from steps that worked.
 3. **Run** with `wengine workflow run <path> <input>` to reproduce the pipeline on demand.
@@ -22,7 +44,7 @@ The standard agent loop is:
 
 `wengine` needs a config file that lists the node types it can resolve. The config is YAML and lives at the path printed by `wengine config path` (typically `~/.config/wengine/config.yaml`). Override per-invocation with `--config <path>`.
 
-```bash
+```sh
 # See the default location
 wengine config path
 
@@ -52,7 +74,7 @@ The engine has a typed value system. Every workflow input, every node port, and 
 To reference a value type from a workflow or node param, wrap its name in `x-value-type`:
 
 ```json
-{"x-value-type": "JSONValue"}
+{ "x-value-type": "JSONValue" }
 ```
 
 For generic types, use the standard JSON Schema shape with `x-value-type` on the inner Value:
@@ -70,8 +92,8 @@ For object schemas with named fields, use `properties` + `required`:
   "title": "Person",
   "required": ["name", "age"],
   "properties": {
-    "name": {"x-value-type": "StringValue", "title": "Full Name"},
-    "age":  {"x-value-type": "IntegerValue", "title": "Age"}
+    "name": { "x-value-type": "StringValue", "title": "Full Name" },
+    "age": { "x-value-type": "IntegerValue", "title": "Age" }
   }
 }
 ```
@@ -85,7 +107,7 @@ The engine has a registry of casts between `Value` types. When a workflow runs, 
 Two implications for agents:
 
 - `wengine workflow edit possible-edges` **already includes castable matches**, not just exact-type matches. If a target appears in the list, the edge is wireable as-is.
-- If `add-edge` rejects an edge with a "not assignable to" error, no cast path exists between those types. You need an intermediate node that bridges them, or a different source field. `possible-edges` from the *target* side will tell you which sources are reachable.
+- If `add-edge` rejects an edge with a "not assignable to" error, no cast path exists between those types. You need an intermediate node that bridges them, or a different source field. `possible-edges` from the _target_ side will tell you which sources are reachable.
 
 ## Reading schemas
 
@@ -96,6 +118,7 @@ Pass `--expanded` to any of those commands to get the full Pydantic schema (`$de
 `schema check` is the one exception: it always emits the expanded form, because its purpose is to demystify a compact `x-value-type` blob into its concrete shape.
 
 When reading either form:
+
 - `required` lists mandatory fields; `additionalProperties: false` rejects extras.
 - In the compact form, each property carries its `title`/`description` directly.
 - In the expanded form, follow each property's `$ref` into `$defs` and read the def's `title` (e.g. `"SequenceValue[FloatValue]"`) for the canonical Value type. `$defs` keys are mangled identifiers — read the title, not the key.
@@ -106,7 +129,7 @@ To validate a value against a schema: `wengine schema parse <schema> <value>`.
 
 ### 1. Explore: run individual nodes
 
-```bash
+```sh
 wengine node run <Name> <params-json> <input-json>
 ```
 
@@ -114,7 +137,7 @@ Inputs accept three forms anywhere `<params>` or `<input>` appears: an inline JS
 
 Example:
 
-```bash
+```sh
 wengine node run Sum '{}' '{"values": [1.5, 2.5, 4.0]}'
 # prints {"sum": 8.0} and writes intermediate files under ./local/<uuid>/
 ```
@@ -124,28 +147,28 @@ wengine node run Sum '{}' '{"values": [1.5, 2.5, 4.0]}'
 Before running, three commands make a node legible:
 
 - `wengine node list` — every registered node with its alias, display name, and description (one row per node). The first column is the alias to use everywhere else.
-- `wengine node info <Name>` — full metadata for one node: display name, description, version, and the **parameter schema** (what goes in the `<params>` argument). Read this *first* whenever you need to construct params.
+- `wengine node info <Name>` — full metadata for one node: display name, description, version, and the **parameter schema** (what goes in the `<params>` argument). Read this _first_ whenever you need to construct params.
 - `wengine node check <Name> <params>` — validates the node with concrete params and prints its **resolved input and output schemas** (compact form by default). This is critical for nodes whose I/O shape is dynamic — e.g. variadic `Add`, where setting `num_arguments=3` causes input fields `a`, `b`, `c` to appear. Always run `node check` after settling on params and before constructing inputs.
 
 ### 2. Compose: build a saved workflow
 
-```bash
+```sh
 wengine workflow init my-flow.json
 ```
 
 Then assemble:
 
-| Subcommand | Purpose |
-| --- | --- |
-| `workflow edit add-field <path> <id>.<name> <schema>` | Add a field to the input or output node |
-| `workflow edit update-field <path> <id>.<name> <schema>` | Change an existing field's schema |
-| `workflow edit remove-field <path> <id>.<name>` | Drop a field (and any edges that reference it) |
-| `workflow edit add-node <path> <Name> <id> [params]` | Add an inner node |
-| `workflow edit update-node <path> <id> <params>` | Replace a node's params (works on input/output too) |
-| `workflow edit remove-node <path> <id>` | Remove an inner node and all touching edges |
-| `workflow edit add-edge <path> <src> <tgt>` | Connect two handles, formatted as `nodeId.handle` |
-| `workflow edit remove-edge <path> <src> <tgt>` | Disconnect a specific edge |
-| `workflow edit possible-edges <path> <id>.<handle>` | List handles compatible with the given handle |
+| Subcommand                                               | Purpose                                             |
+| -------------------------------------------------------- | --------------------------------------------------- |
+| `workflow edit add-field <path> <id>.<name> <schema>`    | Add a field to the input or output node             |
+| `workflow edit update-field <path> <id>.<name> <schema>` | Change an existing field's schema                   |
+| `workflow edit remove-field <path> <id>.<name>`          | Drop a field (and any edges that reference it)      |
+| `workflow edit add-node <path> <Name> <id> [params]`     | Add an inner node                                   |
+| `workflow edit update-node <path> <id> <params>`         | Replace a node's params (works on input/output too) |
+| `workflow edit remove-node <path> <id>`                  | Remove an inner node and all touching edges         |
+| `workflow edit add-edge <path> <src> <tgt>`              | Connect two handles, formatted as `nodeId.handle`   |
+| `workflow edit remove-edge <path> <src> <tgt>`           | Disconnect a specific edge                          |
+| `workflow edit possible-edges <path> <id>.<handle>`      | List handles compatible with the given handle       |
 
 Each edit reloads the file, applies the change, runs full validation, and **only writes back on success** — failed edits leave the file untouched.
 
@@ -153,7 +176,7 @@ When `update-node` / `update-field` change a schema such that an existing edge b
 
 `possible-edges` is the fastest way to discover what to wire next:
 
-```bash
+```sh
 # After adding a Sum node named "summer", what can feed its values input?
 wengine workflow edit possible-edges my-flow.json summer.values
 # -> input.nums         (any compatible source on another node)
@@ -161,7 +184,7 @@ wengine workflow edit possible-edges my-flow.json summer.values
 
 ### 3. Inspect and run
 
-```bash
+```sh
 wengine workflow describe my-flow.json            # human-readable summary
 wengine workflow describe my-flow.json --json     # machine-readable
 wengine workflow check my-flow.json               # validate + emit input/output schemas

--- a/plugins/wengine/skills/wengine/SKILL.md
+++ b/plugins/wengine/skills/wengine/SKILL.md
@@ -7,30 +7,13 @@ description: Use the `wengine` CLI to explore, compose, validate, and run typed 
 
 `wengine` is a CLI for `aceteam-workflow-engine`. It lets you (a) execute single nodes for ad-hoc work, (b) build and validate DAGs of nodes ("workflows") with full type checking, and (c) run those workflows against typed inputs.
 
-## Bundled script
-
-This skill bundles a POSIX `sh` launcher that bootstraps `uv` (if needed), installs the pinned `aceteam-workflow-engine` wheel under `~/.wengine/runtime`, and runs the real CLI. You do not need a global `pip install` or `wengine` on `PATH`.
-
-Per the [agentskills.io convention for scripts](https://agentskills.io/skill-creation/using-scripts), paths are **relative to this skill directory** (the folder that contains `SKILL.md`). The agent should run commands from that directory.
-
-| Script                   | Role                                                                                                |
-| ------------------------ | --------------------------------------------------------------------------------------------------- |
-| **`scripts/wengine.sh`** | CLI entrypoint; pass the same arguments you would pass to `wengine` (subcommands, flags, `--help`). |
-
-Example:
-
-```sh
-sh scripts/wengine.sh --help
-sh scripts/wengine.sh config path
-```
-
-If the environment already has `wengine` on `PATH` from a normal install, you may use `wengine` directly instead of `sh scripts/wengine.sh` in the examples below.
+Run it as **`sh scripts/wengine.sh`** from this skill directory (same arguments as `wengine`; see [using scripts in skills](https://agentskills.io/skill-creation/using-scripts)). If `wengine` is already on `PATH`, you may use that name in the examples below instead.
 
 ## Invoking this skill
 
 This is a playbook, not a parameterized template. The user supplies the task in plain language ("use the wengine skill to prototype a workflow that scrapes pricing data from these URLs"), and you carry it out by following the steps below — substituting the user's goal for the abstract task. You don't need to ask for arguments; pull every concrete detail you need from the user prompt and the surrounding context.
 
-Throughout this document, **`wengine`** in command examples means the CLI itself—use `sh scripts/wengine.sh` from the skill directory when no global `wengine` is available (the common case for agents).
+Throughout this document, **`wengine`** in command examples means the CLI entrypoint (`sh scripts/wengine.sh` from here, or a global `wengine` if installed).
 
 ## The agent loop
 

--- a/plugins/wengine/skills/wengine/scripts/wengine.sh
+++ b/plugins/wengine/skills/wengine/scripts/wengine.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+#
+# scripts/wengine.sh — self-contained launcher for the Workflow Engine CLI
+# ---------------------------------------------
+# Written for POSIX `sh` (not bash): use /bin/sh, dash, or bash in sh mode.
+#
+# If you run this script in place of typing "wengine", it will:
+#   1) Make sure a small tool called "uv" exists (uv installs Python packages quickly).
+#   2) Make sure a private Python environment exists under your home directory,
+#      and that it contains the "aceteam-workflow-engine" package.
+#   3) Start the real wengine program inside that environment, passing along
+#      any arguments you gave (e.g. "node list", "--help").
+#
+# Nothing is installed into the project folder you are in, and we do not rely
+# on whatever Python might be installed system-wide. After setup, we hand off
+# to that private environment's Python and do not stay in this shell script.
+#
+# Common flags use short portable forms (-p, -rf, -f) so they work on BSD and busybox.
+#
+# Advanced: point at a local checkout instead of PyPI:
+#   WENGINE_PACKAGE_SPEC='-e /path/to/workflow-engine' sh scripts/wengine.sh --help
+#
+set -eu
+
+# Version of the library we install from PyPI (must match plugin releases).
+WENGINE_PINNED_VERSION="2.0.0rc11"
+
+# What to "pip install" into the private environment (override for local dev).
+WENGINE_PACKAGE_SPEC="${WENGINE_PACKAGE_SPEC:-aceteam-workflow-engine==${WENGINE_PINNED_VERSION}}"
+
+# All managed files live here (override to put the runtime somewhere else).
+WENGINE_RUNTIME_ROOT="${WENGINE_RUNTIME_ROOT:-${HOME}/.wengine/runtime}"
+
+# Short names for important paths under that root.
+VENV_DIR="${WENGINE_RUNTIME_ROOT}/venv"
+SPEC_FILE="${WENGINE_RUNTIME_ROOT}/.install-spec"
+UV_DIR="${WENGINE_RUNTIME_ROOT}/uv"
+UV_EXE="${UV_DIR}/uv"
+
+# Set by bootstrap() so the trap handler can remove the lock without nested functions
+# (nested functions are not POSIX).
+_wengine_lockdir=
+
+_wengine_release_lock() {
+	rmdir "$_wengine_lockdir" 2>/dev/null || true
+	_wengine_lockdir=
+}
+
+# --- uv (the installer tool) -----------------------------------------------
+# We need the `uv` program to create the Python environment and install packages.
+# Prefer an existing `uv` on the machine; if there is none, download one into
+# UV_DIR once and reuse it forever after.
+resolve_uv() {
+	if command -v uv >/dev/null 2>&1; then
+		UV_BIN="$(command -v uv)"
+		return
+	fi
+	if [ ! -x "$UV_EXE" ]; then
+		mkdir -p "$UV_DIR"
+		# Fail on HTTP errors, stay quiet except real errors, follow redirects.
+		curl --fail --silent --show-error --location \
+			https://astral.sh/uv/install.sh |
+			env UV_INSTALL_DIR="$UV_DIR" sh
+	fi
+	if [ ! -x "$UV_EXE" ]; then
+		echo "wengine.sh: failed to install uv to $UV_EXE" >&2
+		exit 1
+	fi
+	UV_BIN="$UV_EXE"
+}
+
+# --- Is the existing environment still good? --------------------------------
+# We record what we installed in SPEC_FILE. If that matches what we want, the
+# venv folder exists, and Python can import the CLI, we skip reinstalling.
+venv_ok() {
+	[ -f "$SPEC_FILE" ] || return 1
+	[ "$(cat "$SPEC_FILE")" = "$WENGINE_PACKAGE_SPEC" ] || return 1
+	[ -x "${VENV_DIR}/bin/python" ] || return 1
+	"${VENV_DIR}/bin/python" -c "import workflow_engine.cli.main" 2>/dev/null || return 1
+}
+
+# --- Build a fresh private Python environment -------------------------------
+# Work entirely in a temporary folder until everything succeeds, then "swap"
+# it into place so you never end up with half an install as the main venv.
+# (No `local` — not POSIX; these names are only used inside this function.)
+install_venv() {
+	_wengine_staging="venv.staging.$$"
+	_wengine_staging_path="${WENGINE_RUNTIME_ROOT}/${_wengine_staging}"
+	rm -rf "$_wengine_staging_path"
+
+	# Create an isolated Python 3.12 environment (does not touch system Python).
+	"$UV_BIN" venv --python 3.12 "$_wengine_staging_path"
+	# Install the workflow engine and its dependencies into that environment only.
+	"$UV_BIN" pip install --python "${_wengine_staging_path}/bin/python" "$WENGINE_PACKAGE_SPEC"
+
+	# Swap in the new venv without deleting the old one first:
+	# rename current -> backup, rename staging -> current, then delete backup.
+	# If the final rename fails, put the old venv back so you still have a working CLI.
+	_wengine_old="${VENV_DIR}.old.$$"
+	rm -rf "$_wengine_old"
+	if [ -d "$VENV_DIR" ]; then
+		mv "$VENV_DIR" "$_wengine_old"
+	fi
+	if ! mv "$_wengine_staging_path" "$VENV_DIR"; then
+		if [ -d "$_wengine_old" ]; then
+			mv "$_wengine_old" "$VENV_DIR"
+		fi
+		echo "wengine.sh: failed to promote new venv" >&2
+		return 1
+	fi
+	rm -rf "$_wengine_old"
+
+	# Remember what we installed, using a temp file + rename so the file is
+	# never half-written if something crashes mid-save.
+	_wengine_spec_tmp="${SPEC_FILE}.$$"
+	printf '%s' "$WENGINE_PACKAGE_SPEC" >"$_wengine_spec_tmp"
+	mv -f "$_wengine_spec_tmp" "$SPEC_FILE"
+}
+
+# --- Run setup if needed (with a simple lock) --------------------------------
+# Two terminals might run this at once. Only one should install at a time: we
+# create a tiny lock directory (creating a directory is atomic on local disks).
+# Others wait in a loop until the lock disappears.
+#
+# `trap` tells the shell: when any of these happen, run `_wengine_release_lock` once.
+#   EXIT: This process is exiting (success or failure). Drops the lock if
+#         we bail out before the normal cleanup path.
+#   INT:  Ctrl+C (interrupt).
+#   HUP:  Hangup (e.g. terminal closed).
+#   TERM: Polite shutdown (e.g. `kill`).
+bootstrap() {
+	mkdir -p "$WENGINE_RUNTIME_ROOT"
+	_wengine_lockdir="${WENGINE_RUNTIME_ROOT}/.bootstrap-lock"
+	# sleep accepts fractions on many systems; POSIX only requires integer seconds.
+	while ! mkdir "$_wengine_lockdir" 2>/dev/null; do
+		sleep 0.2 2>/dev/null || sleep 1
+	done
+	trap '_wengine_release_lock' EXIT INT HUP TERM
+	resolve_uv
+	if ! venv_ok; then
+		install_venv
+	fi
+	_wengine_release_lock
+	trap - EXIT INT HUP TERM
+}
+
+bootstrap
+
+# Replace this shell process with the real CLI, forwarding all arguments.
+exec "${VENV_DIR}/bin/python" -m workflow_engine.cli.main "$@"

--- a/plugins/wengine/skills/wengine/scripts/wengine.sh
+++ b/plugins/wengine/skills/wengine/scripts/wengine.sh
@@ -5,59 +5,94 @@
 # Written for POSIX `sh` (not bash): use /bin/sh, dash, or bash in sh mode.
 #
 # If you run this script in place of typing "wengine", it will:
-#   1) Make sure a small tool called "uv" exists (uv installs Python packages quickly).
-#   2) Make sure a private Python environment exists under your home directory,
-#      and that it contains the "aceteam-workflow-engine" package.
-#   3) Start the real wengine program inside that environment, passing along
-#      any arguments you gave (e.g. "node list", "--help").
+#   1) Make sure a small tool called "uv" exists (uv installs Python quickly).
+#   2) Make sure a private Python environment exists under your home directory
+#      with aceteam-workflow-engine installed.
+#   3) Start the real wengine program inside that environment, forwarding argv.
 #
-# Nothing is installed into the project folder you are in, and we do not rely
-# on whatever Python might be installed system-wide. After setup, we hand off
-# to that private environment's Python and do not stay in this shell script.
+# Nothing is installed into your current project directory; execution uses the
+# private venv's Python only.
 #
-# Common flags use short portable forms (-p, -rf, -f) so they work on BSD and busybox.
+# Common flags use short portable forms (-p, -rf, -f) for BSD and busybox.
 #
-# Advanced: point at a local checkout instead of PyPI:
-#   WENGINE_PACKAGE_SPEC='-e /path/to/workflow-engine' sh scripts/wengine.sh --help
+# Environment (optional):
+#   WENGINE_RUNTIME_ROOT   — where bootstrap state lives (default ~/.wengine/runtime).
+#   WENGINE_PYTHON         — interpreter for the venv (default 3.12; try 3.13, 3.14, …).
+#   WENGINE_PACKAGE_SPEC   — pip requirement when not using editable (default pinned release).
+#   WENGINE_EDITABLE_PATH  — absolute or relative path to a project root; if set, pip install -e
+#                            that tree instead of WENGINE_PACKAGE_SPEC.
 #
 set -eu
 
 # Version of the library we install from PyPI (must match plugin releases).
 WENGINE_PINNED_VERSION="2.0.0rc11"
 
-# What to "pip install" into the private environment (override for local dev).
+# What to install from PyPI when WENGINE_EDITABLE_PATH is unset.
 WENGINE_PACKAGE_SPEC="${WENGINE_PACKAGE_SPEC:-aceteam-workflow-engine==${WENGINE_PINNED_VERSION}}"
 
-# All managed files live here (override to put the runtime somewhere else).
+WENGINE_PYTHON="${WENGINE_PYTHON:-3.12}"
+
+# Resolved editable root (absolute path) when WENGINE_EDITABLE_PATH is set.
+_wengine_ed_abs=""
+
+if [ -n "${WENGINE_EDITABLE_PATH:-}" ]; then
+	if [ ! -d "$WENGINE_EDITABLE_PATH" ]; then
+		echo "wengine.sh: WENGINE_EDITABLE_PATH must be a directory: $WENGINE_EDITABLE_PATH" >&2
+		exit 1
+	fi
+	_wengine_ed_abs="$(cd "$WENGINE_EDITABLE_PATH" && pwd)"
+	WENGINE_INSTALL_ID="editable:${_wengine_ed_abs}"
+else
+	WENGINE_INSTALL_ID="$WENGINE_PACKAGE_SPEC"
+fi
+
 WENGINE_RUNTIME_ROOT="${WENGINE_RUNTIME_ROOT:-${HOME}/.wengine/runtime}"
 
-# Short names for important paths under that root.
 VENV_DIR="${WENGINE_RUNTIME_ROOT}/venv"
 SPEC_FILE="${WENGINE_RUNTIME_ROOT}/.install-spec"
 UV_DIR="${WENGINE_RUNTIME_ROOT}/uv"
 UV_EXE="${UV_DIR}/uv"
 
-# Set by bootstrap() so the trap handler can remove the lock without nested functions
-# (nested functions are not POSIX).
 _wengine_lockdir=
 
 _wengine_release_lock() {
-	rmdir "$_wengine_lockdir" 2>/dev/null || true
+	rm -rf "$_wengine_lockdir" 2>/dev/null || true
 	_wengine_lockdir=
 }
 
+# If another bootstrap left .bootstrap-lock behind (crash, kill -9), clear it when
+# the recorded PID is gone or missing.
+_wengine_try_stale_lock_release() {
+	if [ ! -d "$_wengine_lockdir" ]; then
+		return 0
+	fi
+	if [ ! -f "$_wengine_lockdir/pid" ]; then
+		rm -rf "$_wengine_lockdir" 2>/dev/null || true
+		return 0
+	fi
+	_wengine_oldpid="$(cat "$_wengine_lockdir/pid" 2>/dev/null || true)"
+	if [ -z "$_wengine_oldpid" ]; then
+		rm -rf "$_wengine_lockdir" 2>/dev/null || true
+		return 0
+	fi
+	if kill -0 "$_wengine_oldpid" 2>/dev/null; then
+		return 0
+	fi
+	rm -rf "$_wengine_lockdir" 2>/dev/null || true
+}
+
 # --- uv (the installer tool) -----------------------------------------------
-# We need the `uv` program to create the Python environment and install packages.
-# Prefer an existing `uv` on the machine; if there is none, download one into
-# UV_DIR once and reuse it forever after.
 resolve_uv() {
 	if command -v uv >/dev/null 2>&1; then
 		UV_BIN="$(command -v uv)"
 		return
 	fi
 	if [ ! -x "$UV_EXE" ]; then
+		if ! command -v curl >/dev/null 2>&1; then
+			echo "wengine.sh: need 'curl' on PATH to download uv, or install uv first (https://docs.astral.sh/uv/)." >&2
+			exit 1
+		fi
 		mkdir -p "$UV_DIR"
-		# Fail on HTTP errors, stay quiet except real errors, follow redirects.
 		curl --fail --silent --show-error --location \
 			https://astral.sh/uv/install.sh |
 			env UV_INSTALL_DIR="$UV_DIR" sh
@@ -69,33 +104,25 @@ resolve_uv() {
 	UV_BIN="$UV_EXE"
 }
 
-# --- Is the existing environment still good? --------------------------------
-# We record what we installed in SPEC_FILE. If that matches what we want, the
-# venv folder exists, and Python can import the CLI, we skip reinstalling.
 venv_ok() {
 	[ -f "$SPEC_FILE" ] || return 1
-	[ "$(cat "$SPEC_FILE")" = "$WENGINE_PACKAGE_SPEC" ] || return 1
+	[ "$(cat "$SPEC_FILE")" = "$WENGINE_INSTALL_ID" ] || return 1
 	[ -x "${VENV_DIR}/bin/python" ] || return 1
 	"${VENV_DIR}/bin/python" -c "import workflow_engine.cli.main" 2>/dev/null || return 1
 }
 
-# --- Build a fresh private Python environment -------------------------------
-# Work entirely in a temporary folder until everything succeeds, then "swap"
-# it into place so you never end up with half an install as the main venv.
-# (No `local` — not POSIX; these names are only used inside this function.)
 install_venv() {
 	_wengine_staging="venv.staging.$$"
 	_wengine_staging_path="${WENGINE_RUNTIME_ROOT}/${_wengine_staging}"
 	rm -rf "$_wengine_staging_path"
 
-	# Create an isolated Python 3.12 environment (does not touch system Python).
-	"$UV_BIN" venv --python 3.12 "$_wengine_staging_path"
-	# Install the workflow engine and its dependencies into that environment only.
-	"$UV_BIN" pip install --python "${_wengine_staging_path}/bin/python" "$WENGINE_PACKAGE_SPEC"
+	"$UV_BIN" venv --python "$WENGINE_PYTHON" "$_wengine_staging_path"
+	if [ -n "${WENGINE_EDITABLE_PATH:-}" ]; then
+		"$UV_BIN" pip install --python "${_wengine_staging_path}/bin/python" -e "$_wengine_ed_abs"
+	else
+		"$UV_BIN" pip install --python "${_wengine_staging_path}/bin/python" "$WENGINE_PACKAGE_SPEC"
+	fi
 
-	# Swap in the new venv without deleting the old one first:
-	# rename current -> backup, rename staging -> current, then delete backup.
-	# If the final rename fails, put the old venv back so you still have a working CLI.
 	_wengine_old="${VENV_DIR}.old.$$"
 	rm -rf "$_wengine_old"
 	if [ -d "$VENV_DIR" ]; then
@@ -110,29 +137,24 @@ install_venv() {
 	fi
 	rm -rf "$_wengine_old"
 
-	# Remember what we installed, using a temp file + rename so the file is
-	# never half-written if something crashes mid-save.
 	_wengine_spec_tmp="${SPEC_FILE}.$$"
-	printf '%s' "$WENGINE_PACKAGE_SPEC" >"$_wengine_spec_tmp"
+	printf '%s' "$WENGINE_INSTALL_ID" >"$_wengine_spec_tmp"
 	mv -f "$_wengine_spec_tmp" "$SPEC_FILE"
 }
 
-# --- Run setup if needed (with a simple lock) --------------------------------
-# Two terminals might run this at once. Only one should install at a time: we
-# create a tiny lock directory (creating a directory is atomic on local disks).
-# Others wait in a loop until the lock disappears.
-#
-# `trap` tells the shell: when any of these happen, run `_wengine_release_lock` once.
-#   EXIT: This process is exiting (success or failure). Drops the lock if
-#         we bail out before the normal cleanup path.
-#   INT:  Ctrl+C (interrupt).
-#   HUP:  Hangup (e.g. terminal closed).
-#   TERM: Polite shutdown (e.g. `kill`).
 bootstrap() {
 	mkdir -p "$WENGINE_RUNTIME_ROOT"
 	_wengine_lockdir="${WENGINE_RUNTIME_ROOT}/.bootstrap-lock"
-	# sleep accepts fractions on many systems; POSIX only requires integer seconds.
-	while ! mkdir "$_wengine_lockdir" 2>/dev/null; do
+	while true; do
+		if mkdir "$_wengine_lockdir" 2>/dev/null; then
+			printf '%s\n' $$ >"$_wengine_lockdir/pid"
+			break
+		fi
+		_wengine_try_stale_lock_release
+		if mkdir "$_wengine_lockdir" 2>/dev/null; then
+			printf '%s\n' $$ >"$_wengine_lockdir/pid"
+			break
+		fi
 		sleep 0.2 2>/dev/null || sleep 1
 	done
 	trap '_wengine_release_lock' EXIT INT HUP TERM
@@ -146,5 +168,4 @@ bootstrap() {
 
 bootstrap
 
-# Replace this shell process with the real CLI, forwarding all arguments.
 exec "${VENV_DIR}/bin/python" -m workflow_engine.cli.main "$@"

--- a/release.sh
+++ b/release.sh
@@ -162,7 +162,10 @@ fi
 echo "Updating version to $NEW_VERSION..."
 sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
 sed -i "s/^__version__ = \".*\"/__version__ = \"$NEW_VERSION\"/" src/workflow_engine/__init__.py
-sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" plugins/wengine/.claude-plugin/plugin.json
+sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" \
+    plugins/wengine/.claude-plugin/plugin.json
+sed -i "s/^WENGINE_PINNED_VERSION=\"[^\"]*\"/WENGINE_PINNED_VERSION=\"$NEW_VERSION\"/" \
+    plugins/wengine/skills/wengine/scripts/wengine.sh
 
 # Run tests
 echo "Running tests..."
@@ -179,7 +182,12 @@ uv run pyright
 
 # Commit version bump
 echo "Committing version bump..."
-git add pyproject.toml src/workflow_engine/__init__.py plugins/wengine/.claude-plugin/plugin.json uv.lock
+git add \
+    pyproject.toml \
+    src/workflow_engine/__init__.py \
+    plugins/wengine/.claude-plugin/plugin.json \
+    plugins/wengine/skills/wengine/scripts/wengine.sh \
+    uv.lock
 git commit -m "Bump version to $NEW_VERSION"
 
 # Create and push tag


### PR DESCRIPTION
- Bundle scripts/wengine.sh (uv bootstrap + pinned wheel + exec CLI)
- Document agentskills-style paths in SKILL.md
- Bump pinned shim version in release.sh; note in CLAUDE.md

---

This PR addresses most of #132 by giving the workflow skill the ability to self-install dependencies through a setup hook that automatically runs the first time we try to execute a `wengine` command, by asking the agent to route its commands through the `wengine.sh` script instead. The only dependency of this script is `sh`, which any self-respecting system should have (though someday we'll consider support for Windows, etc.). Before forwarding the subcommand args to `wengine`, the script runs an idempotent, concurrency-safe installation of all of the dependencies via `uv` or skips it if the dependencies already exist.

This pattern is stronger than `uvx`, which still requires the assumption that `uv` is present in the system.