### PR TITLE
feat: install-target parser for wengine install shorthands

### DIFF
--- a/docs/plans/node-distribution.md
+++ b/docs/plans/node-distribution.md
@@ -185,12 +185,12 @@ hosted engine running workflows submitted by others).
 
 ## Artifacts
 
-| Artifact                                         | Location                                                               | Written by                                            | Purpose                                                              |
-| ------------------------------------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
-| `engine.yaml`                                    | engine project dir                                                     | operator (via `wengine init` / `install`, or by hand) | Maps recognized node names → entry-point refs                        |
-| `pyproject.toml` + `uv.lock`                     | the host project (embedded) **or** the engine project dir (standalone) | operator; `wengine install` mutates them via `uv add` | Which packages are installed, and pinned; **committed to VCS**       |
+| Artifact                                                 | Location                                                               | Written by                                            | Purpose                                                              |
+| -------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `engine.yaml`                                            | engine project dir                                                     | operator (via `wengine init` / `install`, or by hand) | Maps recognized node names → entry-point refs                        |
+| `pyproject.toml` + `uv.lock`                             | the host project (embedded) **or** the engine project dir (standalone) | operator; `wengine install` mutates them via `uv add` | Which packages are installed, and pinned; **committed to VCS**       |
 | `[project.entry-points."aceteam_workflow_engine.nodes"]` | inside each node-source package's `pyproject.toml`                     | node publisher                                        | Declares `nodeName → module:Class` for each node the package exposes |
-| `workflow.json`                                  | wherever workflows live                                                | workflow author                                       | Graph of nodes referenced by bare `type` name                        |
+| `workflow.json`                                          | wherever workflows live                                                | workflow author                                       | Graph of nodes referenced by bare `type` name                        |
 
 `engine.yaml` and `workflow.json` are both required to interpret a workflow; this
 is intentional (see trust model). They are not assumed to come from the same party.
@@ -305,7 +305,7 @@ A node-source package is an ordinary Python distribution. It declares the nodes 
 exposes via [entry points](https://packaging.python.org/en/latest/specifications/entry-points/)
 in its own `pyproject.toml`. The group is `aceteam_workflow_engine.nodes`; each
 entry's name is the node name, and its value is `dotted.module.path:NodeClass` with
-an optional ` [extra1, extra2]` suffix naming the package extras that node needs
+an optional `[extra1, extra2]` suffix naming the package extras that node needs
 (the standard entry-point [extras syntax](https://packaging.python.org/en/latest/specifications/entry-points/),
 which `importlib.metadata` parses — readable without importing the module).
 

--- a/src/workflow_engine/cli/install_target.py
+++ b/src/workflow_engine/cli/install_target.py
@@ -83,9 +83,14 @@ class PathTarget(BaseInstallTarget):
 class ForgeTarget(BaseInstallTarget):
     """A `github:` / `gitlab:` shorthand needing HTTPS ref resolution.
 
-    `to_uv_add_args` resolves the ref to a commit SHA over HTTPS, then hands
+    `uv_add_args` resolves the ref to a commit SHA over HTTPS, then hands
     `uv add` a pinned tarball URL. uv downloads the archive and reads its
-    metadata to discover the distribution name.
+    metadata to discover the distribution name. Reading the property issues
+    network requests — the result is cached on the instance after the first
+    read.
+
+    Only the public `github.com` / `gitlab.com` hosts are supported. For
+    self-hosted instances or GitHub Enterprise, use a `git+https://` URL.
     """
 
     forge: ForgeName

--- a/src/workflow_engine/cli/install_target.py
+++ b/src/workflow_engine/cli/install_target.py
@@ -1,0 +1,207 @@
+"""Parse `wengine install` target strings.
+
+Operators name node-source packages with several shorthands on top of plain pip
+requirements:
+
+- ``acme-scrapers`` / ``acme-scrapers==1.4.0`` / ``acme-scrapers[screenshot]`` —
+  any PyPI (or configured-index) requirement.
+- ``git+https://host/owner/repo@<ref>[#subdirectory=...]`` — a raw ``git+`` URL
+  handed straight to ``uv add``. Needs system ``git``.
+- ``./path`` (or ``../path`` / ``/path``) or ``path:<anything>`` — an editable
+  local install.
+- ``github:owner/repo[@ref][#subdirectory=...]`` / ``gitlab:...`` — forge
+  shorthand: ``wengine`` resolves the ref to a commit SHA over HTTPS and points
+  ``uv`` at a pinned tarball URL. No system ``git`` required.
+- ``owner/repo`` (bare) — shorthand for ``github:owner/repo``.
+
+This module is pure-ish: ``parse_install_target`` does no I/O, and
+``resolve_forge_ref`` takes an injectable HTTP getter so tests can stub the
+network.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.request
+from collections.abc import Callable
+from typing import Literal
+from urllib.parse import quote
+
+from workflow_engine.utils.model import ImmutableBaseModel
+
+ForgeName = Literal["github", "gitlab"]
+
+_FORGE_TARBALL_URL_TEMPLATES: dict[ForgeName, str] = {
+    "github": "https://codeload.github.com/{owner}/{repo}/tar.gz/{sha}",
+    # GitLab's archive endpoint: the trailing filename is cosmetic but required
+    # by the route, and conventionally `<repo>-<sha>.tar.gz`.
+    "gitlab": "https://gitlab.com/{owner}/{repo}/-/archive/{sha}/{repo}-{sha}.tar.gz",
+}
+
+
+class PypiTarget(ImmutableBaseModel):
+    """A PEP 508-style requirement, passed straight through to ``uv add``."""
+
+    requirement: str
+
+    def to_uv_add_args(self) -> tuple[str, ...]:
+        return (self.requirement,)
+
+
+class GitTarget(ImmutableBaseModel):
+    """A raw ``git+`` URL, passed straight through to ``uv add``."""
+
+    url: str
+
+    def to_uv_add_args(self) -> tuple[str, ...]:
+        return (self.url,)
+
+
+class PathTarget(ImmutableBaseModel):
+    """A local path, installed editable."""
+
+    path: str
+
+    def to_uv_add_args(self) -> tuple[str, ...]:
+        return ("--editable", self.path)
+
+
+class ForgeTarget(ImmutableBaseModel):
+    """A ``github:`` / ``gitlab:`` shorthand needing HTTPS ref resolution.
+
+    ``to_uv_add_args`` is not provided here because constructing the final
+    ``uv add`` argument needs both the resolved SHA (see ``resolve_forge_ref``)
+    and, for a direct-URL dependency, the distribution name (read from package
+    metadata at install time). Both belong to the install command, not the
+    parser.
+    """
+
+    forge: ForgeName
+    owner: str
+    repo: str
+    ref: str | None = None
+    """The git ref to install at. ``None`` means resolve the default branch."""
+    subdirectory: str | None = None
+    """Optional subdirectory within the repo containing the package."""
+
+    def tarball_url(self, sha: str) -> str:
+        return _FORGE_TARBALL_URL_TEMPLATES[self.forge].format(
+            owner=self.owner, repo=self.repo, sha=sha
+        )
+
+
+InstallTarget = PypiTarget | GitTarget | PathTarget | ForgeTarget
+
+
+# Forge shorthand: optional `<forge>:` prefix, owner/repo, optional @ref,
+# optional #subdirectory=...
+_FORGE_SHORTHAND_RE = re.compile(
+    r"""
+    ^
+    (?:(?P<forge>github|gitlab):)?
+    (?P<owner>[A-Za-z0-9][A-Za-z0-9._-]*)
+    /
+    (?P<repo>[A-Za-z0-9][A-Za-z0-9._-]*)
+    (?:@(?P<ref>[^#]+))?
+    (?:\#subdirectory=(?P<subdir>.+))?
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_install_target(s: str) -> InstallTarget:
+    """Parse a ``wengine install`` target string.
+
+    Raises ``ValueError`` on empty input. Anything that doesn't look like a
+    git/path/forge shorthand is treated as a PyPI requirement and handed to
+    ``uv add`` as-is — ``uv`` produces the real error if the requirement is
+    malformed.
+    """
+    if not s:
+        raise ValueError("empty install target")
+
+    if s.startswith("git+"):
+        return GitTarget(url=s)
+
+    if s.startswith("path:"):
+        return PathTarget(path=s[len("path:") :])
+    if s.startswith(("./", "../", "/")):
+        return PathTarget(path=s)
+
+    # Explicit forge shorthand (`github:` / `gitlab:`) or a bare `owner/repo`
+    # which defaults to GitHub. PyPI requirements never contain a `/`, so a
+    # slash is the disambiguator. Anything with brackets or version specifiers
+    # falls through to PyPI even if it has a slash.
+    m = _FORGE_SHORTHAND_RE.match(s)
+    if m:
+        forge = m.group("forge") or "github"
+        return ForgeTarget(
+            forge=forge,  # type: ignore[arg-type]
+            owner=m.group("owner"),
+            repo=m.group("repo"),
+            ref=m.group("ref"),
+            subdirectory=m.group("subdir"),
+        )
+
+    return PypiTarget(requirement=s)
+
+
+HttpGetter = Callable[[str], bytes]
+"""HTTPS GET that returns the response body. Injectable for tests."""
+
+
+def _default_http_get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "wengine-install"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read()
+
+
+def resolve_forge_ref(
+    target: ForgeTarget, http_get: HttpGetter = _default_http_get
+) -> str:
+    """Resolve a ``ForgeTarget``'s ref to a commit SHA over HTTPS.
+
+    When ``target.ref`` is ``None``, the repository's default branch is fetched
+    first and then resolved. Returns the commit SHA as a string.
+    """
+    if target.forge == "github":
+        return _resolve_github(target, http_get)
+    if target.forge == "gitlab":
+        return _resolve_gitlab(target, http_get)
+    raise AssertionError(f"unreachable forge: {target.forge!r}")
+
+
+def _resolve_github(target: ForgeTarget, http_get: HttpGetter) -> str:
+    base = f"https://api.github.com/repos/{target.owner}/{target.repo}"
+    ref = target.ref
+    if ref is None:
+        repo_info = json.loads(http_get(base))
+        ref = repo_info["default_branch"]
+    commit = json.loads(http_get(f"{base}/commits/{quote(ref, safe='')}"))
+    return commit["sha"]
+
+
+def _resolve_gitlab(target: ForgeTarget, http_get: HttpGetter) -> str:
+    project = quote(f"{target.owner}/{target.repo}", safe="")
+    base = f"https://gitlab.com/api/v4/projects/{project}"
+    ref = target.ref
+    if ref is None:
+        project_info = json.loads(http_get(base))
+        ref = project_info["default_branch"]
+    commit = json.loads(http_get(f"{base}/repository/commits/{quote(ref, safe='')}"))
+    return commit["id"]
+
+
+__all__ = [
+    "ForgeName",
+    "ForgeTarget",
+    "GitTarget",
+    "HttpGetter",
+    "InstallTarget",
+    "PathTarget",
+    "PypiTarget",
+    "parse_install_target",
+    "resolve_forge_ref",
+]

--- a/src/workflow_engine/cli/install_target.py
+++ b/src/workflow_engine/cli/install_target.py
@@ -3,20 +3,19 @@
 Operators name node-source packages with several shorthands on top of plain pip
 requirements:
 
-- ``acme-scrapers`` / ``acme-scrapers==1.4.0`` / ``acme-scrapers[screenshot]`` —
+- `acme-scrapers` / `acme-scrapers==1.4.0` / `acme-scrapers[screenshot]` —
   any PyPI (or configured-index) requirement.
-- ``git+https://host/owner/repo@<ref>[#subdirectory=...]`` — a raw ``git+`` URL
-  handed straight to ``uv add``. Needs system ``git``.
-- ``./path`` (or ``../path`` / ``/path``) or ``path:<anything>`` — an editable
+- `git+https://host/owner/repo@<ref>[#subdirectory=...]` — a raw `git+` URL
+  handed straight to `uv add`. Needs system `git`.
+- `./path` (or `../path` / `/path`) or `path:<anything>` — an editable
   local install.
-- ``github:owner/repo[@ref][#subdirectory=...]`` / ``gitlab:...`` — forge
-  shorthand: ``wengine`` resolves the ref to a commit SHA over HTTPS and points
-  ``uv`` at a pinned tarball URL. No system ``git`` required.
-- ``owner/repo`` (bare) — shorthand for ``github:owner/repo``.
+- `github:owner/repo[@ref][#subdirectory=...]` / `gitlab:...` — forge
+  shorthand: `wengine` resolves the ref to a commit SHA over HTTPS and points
+  `uv` at a pinned tarball URL. No system `git` required.
+- `owner/repo` (bare) — shorthand for `github:owner/repo`.
 
-This module is pure-ish: ``parse_install_target`` does no I/O, and
-``resolve_forge_ref`` takes an injectable HTTP getter so tests can stub the
-network.
+`parse_install_target` does no I/O. `resolve_forge_ref` performs HTTPS GETs
+via the module-private `_http_get`, which tests monkeypatch.
 """
 
 from __future__ import annotations
@@ -24,7 +23,9 @@ from __future__ import annotations
 import json
 import re
 import urllib.request
-from collections.abc import Callable
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from functools import cached_property
 from typing import Literal
 from urllib.parse import quote
 
@@ -32,7 +33,7 @@ from workflow_engine.utils.model import ImmutableBaseModel
 
 ForgeName = Literal["github", "gitlab"]
 
-_FORGE_TARBALL_URL_TEMPLATES: dict[ForgeName, str] = {
+_FORGE_TARBALL_URL_TEMPLATES: Mapping[ForgeName, str] = {
     "github": "https://codeload.github.com/{owner}/{repo}/tar.gz/{sha}",
     # GitLab's archive endpoint: the trailing filename is cosmetic but required
     # by the route, and conventionally `<repo>-<sha>.tar.gz`.
@@ -40,58 +41,75 @@ _FORGE_TARBALL_URL_TEMPLATES: dict[ForgeName, str] = {
 }
 
 
-class PypiTarget(ImmutableBaseModel):
-    """A PEP 508-style requirement, passed straight through to ``uv add``."""
+class BaseInstallTarget(ImmutableBaseModel, ABC):
+    """Common base for parsed `wengine install` targets."""
+
+    @cached_property
+    @abstractmethod
+    def uv_add_args(self) -> Sequence[str]:
+        """The argv tail to splice after `uv add`."""
+
+
+class PyPITarget(BaseInstallTarget):
+    """A PEP 508-style requirement, passed straight through to `uv add`."""
 
     requirement: str
 
-    def to_uv_add_args(self) -> tuple[str, ...]:
+    @cached_property
+    def uv_add_args(self) -> Sequence[str]:
         return (self.requirement,)
 
 
-class GitTarget(ImmutableBaseModel):
-    """A raw ``git+`` URL, passed straight through to ``uv add``."""
+class GitTarget(BaseInstallTarget):
+    """A raw `git+` URL, passed straight through to `uv add`."""
 
     url: str
 
-    def to_uv_add_args(self) -> tuple[str, ...]:
+    @cached_property
+    def uv_add_args(self) -> Sequence[str]:
         return (self.url,)
 
 
-class PathTarget(ImmutableBaseModel):
+class PathTarget(BaseInstallTarget):
     """A local path, installed editable."""
 
     path: str
 
-    def to_uv_add_args(self) -> tuple[str, ...]:
+    @cached_property
+    def uv_add_args(self) -> Sequence[str]:
         return ("--editable", self.path)
 
 
-class ForgeTarget(ImmutableBaseModel):
-    """A ``github:`` / ``gitlab:`` shorthand needing HTTPS ref resolution.
+class ForgeTarget(BaseInstallTarget):
+    """A `github:` / `gitlab:` shorthand needing HTTPS ref resolution.
 
-    ``to_uv_add_args`` is not provided here because constructing the final
-    ``uv add`` argument needs both the resolved SHA (see ``resolve_forge_ref``)
-    and, for a direct-URL dependency, the distribution name (read from package
-    metadata at install time). Both belong to the install command, not the
-    parser.
+    `to_uv_add_args` resolves the ref to a commit SHA over HTTPS, then hands
+    `uv add` a pinned tarball URL. uv downloads the archive and reads its
+    metadata to discover the distribution name.
     """
 
     forge: ForgeName
     owner: str
     repo: str
     ref: str | None = None
-    """The git ref to install at. ``None`` means resolve the default branch."""
+    """The git ref to install at. `None` means resolve the default branch."""
     subdirectory: str | None = None
     """Optional subdirectory within the repo containing the package."""
 
     def tarball_url(self, sha: str) -> str:
         return _FORGE_TARBALL_URL_TEMPLATES[self.forge].format(
-            owner=self.owner, repo=self.repo, sha=sha
+            owner=self.owner,
+            repo=self.repo,
+            sha=sha,
         )
 
+    @cached_property
+    def uv_add_args(self) -> Sequence[str]:
+        sha = resolve_forge_ref(self)
+        return (self.tarball_url(sha),)
 
-InstallTarget = PypiTarget | GitTarget | PathTarget | ForgeTarget
+
+InstallTarget = PyPITarget | GitTarget | PathTarget | ForgeTarget
 
 
 # Forge shorthand: optional `<forge>:` prefix, owner/repo, optional @ref,
@@ -112,11 +130,11 @@ _FORGE_SHORTHAND_RE = re.compile(
 
 
 def parse_install_target(s: str) -> InstallTarget:
-    """Parse a ``wengine install`` target string.
+    """Parse a `wengine install` target string.
 
-    Raises ``ValueError`` on empty input. Anything that doesn't look like a
+    Raises `ValueError` on empty input. Anything that doesn't look like a
     git/path/forge shorthand is treated as a PyPI requirement and handed to
-    ``uv add`` as-is — ``uv`` produces the real error if the requirement is
+    `uv add` as-is — `uv` produces the real error if the requirement is
     malformed.
     """
     if not s:
@@ -134,74 +152,69 @@ def parse_install_target(s: str) -> InstallTarget:
     # which defaults to GitHub. PyPI requirements never contain a `/`, so a
     # slash is the disambiguator. Anything with brackets or version specifiers
     # falls through to PyPI even if it has a slash.
-    m = _FORGE_SHORTHAND_RE.match(s)
-    if m:
-        forge = m.group("forge") or "github"
+
+    if (match := _FORGE_SHORTHAND_RE.match(s)) is not None:
+        forge = match.group("forge") or "github"
         return ForgeTarget(
             forge=forge,  # type: ignore[arg-type]
-            owner=m.group("owner"),
-            repo=m.group("repo"),
-            ref=m.group("ref"),
-            subdirectory=m.group("subdir"),
+            owner=match.group("owner"),
+            repo=match.group("repo"),
+            ref=match.group("ref"),
+            subdirectory=match.group("subdir"),
         )
 
-    return PypiTarget(requirement=s)
+    return PyPITarget(requirement=s)
 
 
-HttpGetter = Callable[[str], bytes]
-"""HTTPS GET that returns the response body. Injectable for tests."""
-
-
-def _default_http_get(url: str) -> bytes:
+def _http_get(url: str) -> bytes:
+    """HTTPS GET returning the response body. Tests monkeypatch this."""
     req = urllib.request.Request(url, headers={"User-Agent": "wengine-install"})
     with urllib.request.urlopen(req, timeout=30) as resp:
         return resp.read()
 
 
-def resolve_forge_ref(
-    target: ForgeTarget, http_get: HttpGetter = _default_http_get
-) -> str:
-    """Resolve a ``ForgeTarget``'s ref to a commit SHA over HTTPS.
+def resolve_forge_ref(target: ForgeTarget) -> str:
+    """Resolve a `ForgeTarget`'s ref to a commit SHA over HTTPS.
 
-    When ``target.ref`` is ``None``, the repository's default branch is fetched
+    When `target.ref` is `None`, the repository's default branch is fetched
     first and then resolved. Returns the commit SHA as a string.
     """
     if target.forge == "github":
-        return _resolve_github(target, http_get)
+        return _resolve_github(target)
     if target.forge == "gitlab":
-        return _resolve_gitlab(target, http_get)
+        return _resolve_gitlab(target)
     raise AssertionError(f"unreachable forge: {target.forge!r}")
 
 
-def _resolve_github(target: ForgeTarget, http_get: HttpGetter) -> str:
+def _resolve_github(target: ForgeTarget) -> str:
     base = f"https://api.github.com/repos/{target.owner}/{target.repo}"
     ref = target.ref
     if ref is None:
-        repo_info = json.loads(http_get(base))
+        repo_info = json.loads(_http_get(base))
         ref = repo_info["default_branch"]
-    commit = json.loads(http_get(f"{base}/commits/{quote(ref, safe='')}"))
+    commit = json.loads(_http_get(f"{base}/commits/{quote(ref, safe='')}"))
     return commit["sha"]
 
 
-def _resolve_gitlab(target: ForgeTarget, http_get: HttpGetter) -> str:
+def _resolve_gitlab(target: ForgeTarget) -> str:
     project = quote(f"{target.owner}/{target.repo}", safe="")
     base = f"https://gitlab.com/api/v4/projects/{project}"
     ref = target.ref
     if ref is None:
-        project_info = json.loads(http_get(base))
+        project_info = json.loads(_http_get(base))
         ref = project_info["default_branch"]
-    commit = json.loads(http_get(f"{base}/repository/commits/{quote(ref, safe='')}"))
+    commit = json.loads(_http_get(f"{base}/repository/commits/{quote(ref, safe='')}"))
     return commit["id"]
 
 
 __all__ = [
+    "BaseInstallTarget",
     "ForgeName",
     "ForgeTarget",
     "GitTarget",
-    "HttpGetter",
     "InstallTarget",
     "PathTarget",
-    "PypiTarget",
+    "PyPITarget",
     "parse_install_target",
     "resolve_forge_ref",
 ]

--- a/tests/test_install_target.py
+++ b/tests/test_install_target.py
@@ -1,0 +1,230 @@
+"""Tests for the `wengine install` target parser and forge ref resolver."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from workflow_engine.cli.install_target import (
+    ForgeTarget,
+    GitTarget,
+    PathTarget,
+    PypiTarget,
+    parse_install_target,
+    resolve_forge_ref,
+)
+
+
+class TestParsePypi:
+    def test_bare_name(self):
+        t = parse_install_target("acme-scrapers")
+        assert isinstance(t, PypiTarget)
+        assert t.requirement == "acme-scrapers"
+        assert t.to_uv_add_args() == ("acme-scrapers",)
+
+    def test_with_version_specifier(self):
+        t = parse_install_target("acme-scrapers==1.4.0")
+        assert isinstance(t, PypiTarget)
+        assert t.requirement == "acme-scrapers==1.4.0"
+
+    def test_with_extras(self):
+        t = parse_install_target("acme-scrapers[screenshot]")
+        assert isinstance(t, PypiTarget)
+        assert t.requirement == "acme-scrapers[screenshot]"
+
+    def test_with_extras_and_version(self):
+        t = parse_install_target("acme-scrapers[screenshot,crawl-site]>=1.4")
+        assert isinstance(t, PypiTarget)
+        assert t.requirement == "acme-scrapers[screenshot,crawl-site]>=1.4"
+
+
+class TestParseGit:
+    def test_https(self):
+        t = parse_install_target("git+https://gitlab.com/acme/iteration.git@main")
+        assert isinstance(t, GitTarget)
+        assert t.url == "git+https://gitlab.com/acme/iteration.git@main"
+        assert t.to_uv_add_args() == ("git+https://gitlab.com/acme/iteration.git@main",)
+
+    def test_with_subdirectory(self):
+        url = "git+https://github.com/acme/big-monorepo@main#subdirectory=tools/nodes"
+        t = parse_install_target(url)
+        assert isinstance(t, GitTarget)
+        assert t.url == url
+
+
+class TestParsePath:
+    def test_dot_slash(self):
+        t = parse_install_target("./vendor/internal-nodes")
+        assert isinstance(t, PathTarget)
+        assert t.path == "./vendor/internal-nodes"
+        assert t.to_uv_add_args() == ("--editable", "./vendor/internal-nodes")
+
+    def test_parent(self):
+        t = parse_install_target("../sibling")
+        assert isinstance(t, PathTarget)
+        assert t.path == "../sibling"
+
+    def test_absolute(self):
+        t = parse_install_target("/opt/internal-nodes")
+        assert isinstance(t, PathTarget)
+        assert t.path == "/opt/internal-nodes"
+
+    def test_path_prefix(self):
+        t = parse_install_target("path:./vendor/internal-nodes")
+        assert isinstance(t, PathTarget)
+        assert t.path == "./vendor/internal-nodes"
+
+    def test_path_prefix_strips_only_prefix(self):
+        # `path:` is just a disambiguator; the remainder is used verbatim.
+        t = parse_install_target("path:relative/dir")
+        assert isinstance(t, PathTarget)
+        assert t.path == "relative/dir"
+
+
+class TestParseForge:
+    def test_github_explicit_with_ref(self):
+        t = parse_install_target("github:acme/iteration@v2.0.0")
+        assert isinstance(t, ForgeTarget)
+        assert t.forge == "github"
+        assert t.owner == "acme"
+        assert t.repo == "iteration"
+        assert t.ref == "v2.0.0"
+        assert t.subdirectory is None
+
+    def test_github_default_branch(self):
+        t = parse_install_target("github:acme/iteration")
+        assert isinstance(t, ForgeTarget)
+        assert t.ref is None
+
+    def test_gitlab_explicit(self):
+        t = parse_install_target("gitlab:acme/scrapers@1.4.0")
+        assert isinstance(t, ForgeTarget)
+        assert t.forge == "gitlab"
+        assert t.owner == "acme"
+        assert t.repo == "scrapers"
+        assert t.ref == "1.4.0"
+
+    def test_bare_owner_repo_defaults_to_github(self):
+        t = parse_install_target("acme/iteration")
+        assert isinstance(t, ForgeTarget)
+        assert t.forge == "github"
+        assert t.ref is None
+
+    def test_with_subdirectory(self):
+        t = parse_install_target(
+            "github:acme/big-monorepo@main#subdirectory=tools/nodes"
+        )
+        assert isinstance(t, ForgeTarget)
+        assert t.subdirectory == "tools/nodes"
+        assert t.ref == "main"
+
+    def test_ref_can_contain_slash(self):
+        # Branch names like `release/v1` should round-trip.
+        t = parse_install_target("github:acme/iteration@release/v1")
+        assert isinstance(t, ForgeTarget)
+        assert t.ref == "release/v1"
+
+
+class TestParseRejection:
+    def test_empty(self):
+        with pytest.raises(ValueError, match="empty"):
+            parse_install_target("")
+
+    def test_pypi_with_slash_falls_through(self):
+        # `foo/bar[extras]` looks pypi-ish (brackets); regex won't match
+        # because of the trailing `[`, so it falls through to PyPI and `uv add`
+        # is left to complain.
+        t = parse_install_target("foo/bar[extras]")
+        assert isinstance(t, PypiTarget)
+
+
+class TestForgeTarballUrl:
+    def test_github(self):
+        t = ForgeTarget(forge="github", owner="acme", repo="iteration")
+        assert (
+            t.tarball_url("abc123")
+            == "https://codeload.github.com/acme/iteration/tar.gz/abc123"
+        )
+
+    def test_gitlab(self):
+        t = ForgeTarget(forge="gitlab", owner="acme", repo="scrapers")
+        assert (
+            t.tarball_url("deadbeef")
+            == "https://gitlab.com/acme/scrapers/-/archive/deadbeef/scrapers-deadbeef.tar.gz"
+        )
+
+
+class TestResolveForgeRef:
+    def test_github_explicit_ref(self):
+        calls: list[str] = []
+
+        def http_get(url: str) -> bytes:
+            calls.append(url)
+            assert url == "https://api.github.com/repos/acme/iteration/commits/v2.0.0"
+            return json.dumps({"sha": "3f2a9c1d8e0b"}).encode()
+
+        target = ForgeTarget(
+            forge="github", owner="acme", repo="iteration", ref="v2.0.0"
+        )
+        sha = resolve_forge_ref(target, http_get=http_get)
+        assert sha == "3f2a9c1d8e0b"
+        assert len(calls) == 1
+
+    def test_github_default_branch(self):
+        responses = {
+            "https://api.github.com/repos/acme/iteration": {"default_branch": "trunk"},
+            "https://api.github.com/repos/acme/iteration/commits/trunk": {
+                "sha": "deadbeef"
+            },
+        }
+
+        def http_get(url: str) -> bytes:
+            return json.dumps(responses[url]).encode()
+
+        target = ForgeTarget(forge="github", owner="acme", repo="iteration")
+        assert resolve_forge_ref(target, http_get=http_get) == "deadbeef"
+
+    def test_github_url_encodes_ref(self):
+        captured: list[str] = []
+
+        def http_get(url: str) -> bytes:
+            captured.append(url)
+            return json.dumps({"sha": "abc"}).encode()
+
+        target = ForgeTarget(
+            forge="github", owner="acme", repo="iteration", ref="release/v1"
+        )
+        resolve_forge_ref(target, http_get=http_get)
+        # `/` in the ref must be encoded so it doesn't get treated as a path
+        # segment in the API URL.
+        assert captured == [
+            "https://api.github.com/repos/acme/iteration/commits/release%2Fv1"
+        ]
+
+    def test_gitlab_explicit_ref(self):
+        def http_get(url: str) -> bytes:
+            assert url == (
+                "https://gitlab.com/api/v4/projects/acme%2Fscrapers"
+                "/repository/commits/1.4.0"
+            )
+            return json.dumps({"id": "cafef00d"}).encode()
+
+        target = ForgeTarget(forge="gitlab", owner="acme", repo="scrapers", ref="1.4.0")
+        assert resolve_forge_ref(target, http_get=http_get) == "cafef00d"
+
+    def test_gitlab_default_branch(self):
+        responses = {
+            "https://gitlab.com/api/v4/projects/acme%2Fscrapers": {
+                "default_branch": "main"
+            },
+            "https://gitlab.com/api/v4/projects/acme%2Fscrapers/repository/commits/main": {
+                "id": "feedface"
+            },
+        }
+
+        def http_get(url: str) -> bytes:
+            return json.dumps(responses[url]).encode()
+
+        target = ForgeTarget(forge="gitlab", owner="acme", repo="scrapers")
+        assert resolve_forge_ref(target, http_get=http_get) == "feedface"

--- a/tests/test_install_target.py
+++ b/tests/test_install_target.py
@@ -6,11 +6,12 @@ import json
 
 import pytest
 
+from workflow_engine.cli import install_target as install_target_module
 from workflow_engine.cli.install_target import (
     ForgeTarget,
     GitTarget,
     PathTarget,
-    PypiTarget,
+    PyPITarget,
     parse_install_target,
     resolve_forge_ref,
 )
@@ -19,23 +20,23 @@ from workflow_engine.cli.install_target import (
 class TestParsePypi:
     def test_bare_name(self):
         t = parse_install_target("acme-scrapers")
-        assert isinstance(t, PypiTarget)
+        assert isinstance(t, PyPITarget)
         assert t.requirement == "acme-scrapers"
-        assert t.to_uv_add_args() == ("acme-scrapers",)
+        assert t.uv_add_args == ("acme-scrapers",)
 
     def test_with_version_specifier(self):
         t = parse_install_target("acme-scrapers==1.4.0")
-        assert isinstance(t, PypiTarget)
+        assert isinstance(t, PyPITarget)
         assert t.requirement == "acme-scrapers==1.4.0"
 
     def test_with_extras(self):
         t = parse_install_target("acme-scrapers[screenshot]")
-        assert isinstance(t, PypiTarget)
+        assert isinstance(t, PyPITarget)
         assert t.requirement == "acme-scrapers[screenshot]"
 
     def test_with_extras_and_version(self):
         t = parse_install_target("acme-scrapers[screenshot,crawl-site]>=1.4")
-        assert isinstance(t, PypiTarget)
+        assert isinstance(t, PyPITarget)
         assert t.requirement == "acme-scrapers[screenshot,crawl-site]>=1.4"
 
 
@@ -44,7 +45,7 @@ class TestParseGit:
         t = parse_install_target("git+https://gitlab.com/acme/iteration.git@main")
         assert isinstance(t, GitTarget)
         assert t.url == "git+https://gitlab.com/acme/iteration.git@main"
-        assert t.to_uv_add_args() == ("git+https://gitlab.com/acme/iteration.git@main",)
+        assert t.uv_add_args == ("git+https://gitlab.com/acme/iteration.git@main",)
 
     def test_with_subdirectory(self):
         url = "git+https://github.com/acme/big-monorepo@main#subdirectory=tools/nodes"
@@ -58,7 +59,7 @@ class TestParsePath:
         t = parse_install_target("./vendor/internal-nodes")
         assert isinstance(t, PathTarget)
         assert t.path == "./vendor/internal-nodes"
-        assert t.to_uv_add_args() == ("--editable", "./vendor/internal-nodes")
+        assert t.uv_add_args == ("--editable", "./vendor/internal-nodes")
 
     def test_parent(self):
         t = parse_install_target("../sibling")
@@ -136,7 +137,7 @@ class TestParseRejection:
         # because of the trailing `[`, so it falls through to PyPI and `uv add`
         # is left to complain.
         t = parse_install_target("foo/bar[extras]")
-        assert isinstance(t, PypiTarget)
+        assert isinstance(t, PyPITarget)
 
 
 class TestForgeTarballUrl:
@@ -155,76 +156,90 @@ class TestForgeTarballUrl:
         )
 
 
-class TestResolveForgeRef:
-    def test_github_explicit_ref(self):
-        calls: list[str] = []
+class TestForgeUvAddArgs:
+    def test_resolves_and_returns_tarball_url(self, monkeypatch):
+        url = "https://api.github.com/repos/acme/iteration/commits/v2.0.0"
+        _patch_http_get(monkeypatch, {url: {"sha": "abc123"}})
 
-        def http_get(url: str) -> bytes:
-            calls.append(url)
-            assert url == "https://api.github.com/repos/acme/iteration/commits/v2.0.0"
-            return json.dumps({"sha": "3f2a9c1d8e0b"}).encode()
+        t = ForgeTarget(forge="github", owner="acme", repo="iteration", ref="v2.0.0")
+        assert t.uv_add_args == (
+            "https://codeload.github.com/acme/iteration/tar.gz/abc123",
+        )
+
+
+def _patch_http_get(monkeypatch, responses: dict[str, dict]) -> list[str]:
+    """Patch `_http_get` to return canned JSON responses; record calls."""
+    calls: list[str] = []
+
+    def fake(url: str) -> bytes:
+        calls.append(url)
+        return json.dumps(responses[url]).encode()
+
+    monkeypatch.setattr(install_target_module, "_http_get", fake)
+    return calls
+
+
+class TestResolveForgeRef:
+    def test_github_explicit_ref(self, monkeypatch):
+        url = "https://api.github.com/repos/acme/iteration/commits/v2.0.0"
+        calls = _patch_http_get(monkeypatch, {url: {"sha": "3f2a9c1d8e0b"}})
 
         target = ForgeTarget(
             forge="github", owner="acme", repo="iteration", ref="v2.0.0"
         )
-        sha = resolve_forge_ref(target, http_get=http_get)
-        assert sha == "3f2a9c1d8e0b"
-        assert len(calls) == 1
+        assert resolve_forge_ref(target) == "3f2a9c1d8e0b"
+        assert calls == [url]
 
-    def test_github_default_branch(self):
-        responses = {
-            "https://api.github.com/repos/acme/iteration": {"default_branch": "trunk"},
-            "https://api.github.com/repos/acme/iteration/commits/trunk": {
-                "sha": "deadbeef"
+    def test_github_default_branch(self, monkeypatch):
+        _patch_http_get(
+            monkeypatch,
+            {
+                "https://api.github.com/repos/acme/iteration": {
+                    "default_branch": "trunk"
+                },
+                "https://api.github.com/repos/acme/iteration/commits/trunk": {
+                    "sha": "deadbeef"
+                },
             },
-        }
-
-        def http_get(url: str) -> bytes:
-            return json.dumps(responses[url]).encode()
+        )
 
         target = ForgeTarget(forge="github", owner="acme", repo="iteration")
-        assert resolve_forge_ref(target, http_get=http_get) == "deadbeef"
+        assert resolve_forge_ref(target) == "deadbeef"
 
-    def test_github_url_encodes_ref(self):
-        captured: list[str] = []
-
-        def http_get(url: str) -> bytes:
-            captured.append(url)
-            return json.dumps({"sha": "abc"}).encode()
+    def test_github_url_encodes_ref(self, monkeypatch):
+        # `/` in the ref must be encoded so it doesn't get treated as a path
+        # segment in the API URL.
+        url = "https://api.github.com/repos/acme/iteration/commits/release%2Fv1"
+        calls = _patch_http_get(monkeypatch, {url: {"sha": "abc"}})
 
         target = ForgeTarget(
             forge="github", owner="acme", repo="iteration", ref="release/v1"
         )
-        resolve_forge_ref(target, http_get=http_get)
-        # `/` in the ref must be encoded so it doesn't get treated as a path
-        # segment in the API URL.
-        assert captured == [
-            "https://api.github.com/repos/acme/iteration/commits/release%2Fv1"
-        ]
+        resolve_forge_ref(target)
+        assert calls == [url]
 
-    def test_gitlab_explicit_ref(self):
-        def http_get(url: str) -> bytes:
-            assert url == (
-                "https://gitlab.com/api/v4/projects/acme%2Fscrapers"
-                "/repository/commits/1.4.0"
-            )
-            return json.dumps({"id": "cafef00d"}).encode()
+    def test_gitlab_explicit_ref(self, monkeypatch):
+        url = (
+            "https://gitlab.com/api/v4/projects/acme%2Fscrapers"
+            "/repository/commits/1.4.0"
+        )
+        _patch_http_get(monkeypatch, {url: {"id": "cafef00d"}})
 
         target = ForgeTarget(forge="gitlab", owner="acme", repo="scrapers", ref="1.4.0")
-        assert resolve_forge_ref(target, http_get=http_get) == "cafef00d"
+        assert resolve_forge_ref(target) == "cafef00d"
 
-    def test_gitlab_default_branch(self):
-        responses = {
-            "https://gitlab.com/api/v4/projects/acme%2Fscrapers": {
-                "default_branch": "main"
+    def test_gitlab_default_branch(self, monkeypatch):
+        _patch_http_get(
+            monkeypatch,
+            {
+                "https://gitlab.com/api/v4/projects/acme%2Fscrapers": {
+                    "default_branch": "main"
+                },
+                "https://gitlab.com/api/v4/projects/acme%2Fscrapers/repository/commits/main": {
+                    "id": "feedface"
+                },
             },
-            "https://gitlab.com/api/v4/projects/acme%2Fscrapers/repository/commits/main": {
-                "id": "feedface"
-            },
-        }
-
-        def http_get(url: str) -> bytes:
-            return json.dumps(responses[url]).encode()
+        )
 
         target = ForgeTarget(forge="gitlab", owner="acme", repo="scrapers")
-        assert resolve_forge_ref(target, http_get=http_get) == "feedface"
+        assert resolve_forge_ref(target) == "feedface"


### PR DESCRIPTION
## Summary

PR 2 of the node-distribution series (`docs/plans/node-distribution.md`). Parses the operator-facing `wengine install <target>` strings into a structured `InstallTarget` and turns each variant into an argv tail for `uv add`.

- `parse_install_target(s)` → `PyPITarget | GitTarget | PathTarget | ForgeTarget` (all `BaseInstallTarget` subclasses). Pure, no I/O.
  - PyPI: bare names, version specifiers, extras (`acme-scrapers[screenshot]==1.4.0`) — passed through to `uv add` as-is.
  - Git: `git+https://...@ref[#subdirectory=...]` — passed through.
  - Path: `./path`, `../path`, `/abs/path`, or `path:<anything>` — `uv add --editable`.
  - Forge: `github:owner/repo[@ref][#subdirectory=...]`, `gitlab:...`, and bare `owner/repo` (defaults to GitHub).
- Every variant exposes `uv_add_args` as a `cached_property`. For PyPI/Git/Path it's a trivial accessor; for `ForgeTarget` it resolves the ref over HTTPS to a commit SHA, then returns the pinned tarball URL. uv reads the archive metadata itself, so no separate distname lookup is needed.
- `resolve_forge_ref(target)` is also exposed directly. It calls a module-private `_http_get`; tests monkeypatch that name rather than passing an injected getter.

Only the public `github.com` / `gitlab.com` hosts are supported; self-hosted GitLab and GitHub Enterprise users should reach for `git+https://` instead.

## What this PR does *not* do

Nothing user-visible yet — no CLI command wires this up. That lands in PR 3 (`uv` integration / `wengine install`). This PR is structural pre-work, kept standalone so its parsing edge cases can be reviewed and tested in isolation.

## Test plan

- [x] `uv run pytest tests/test_install_target.py` — 27 tests covering every shorthand, malformed input, default-branch lookup, URL-encoded refs, both forges, and `ForgeTarget.uv_add_args` end-to-end with `_http_get` monkeypatched
- [x] Full suite passes
- [x] `ruff check` / `ruff format` / `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)