### PR TITLE
feat: uv-project discovery and shell-out

### DIFF
--- a/src/workflow_engine/cli/uv_project.py
+++ b/src/workflow_engine/cli/uv_project.py
@@ -1,0 +1,152 @@
+"""Locate the `uv` project that backs an `engine.yaml`, and drive `uv` against it.
+
+Two modes:
+
+- **Embedded**: `engine.yaml` lives inside an existing `uv`/Python project (a
+  `pyproject.toml` somewhere at or above `engine.yaml`'s directory). `wengine
+  install` mutates the host project's `pyproject.toml` and `uv.lock`.
+- **Standalone**: no enclosing `pyproject.toml`. `wengine` owns a minimal
+  `pyproject.toml` written next to `engine.yaml` whose sole purpose is to
+  pin the operator's chosen node-source packages.
+
+Discovery walks up from a starting directory looking for `engine.yaml` (or
+`engine.yml`), then walks up again from that directory looking for
+`pyproject.toml` to decide the mode.
+
+Subprocess invocation goes through the module-private `_run_uv`, which tests
+monkeypatch.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal
+
+ENGINE_YAML_NAMES: tuple[str, ...] = ("engine.yaml", "engine.yml")
+
+UvMode = Literal["embedded", "standalone"]
+
+
+_MINIMAL_PYPROJECT = """\
+[project]
+name = "wengine-nodes"
+version = "0.0.0"
+description = "Node-source packages managed by wengine."
+requires-python = ">=3.12"
+dependencies = []
+"""
+
+
+class EngineYamlNotFound(FileNotFoundError):
+    """Raised when no `engine.yaml` is found by walking up from a start dir."""
+
+
+def find_engine_yaml(start: Path) -> Path | None:
+    """Walk up from `start` looking for `engine.yaml` / `engine.yml`.
+
+    Returns the first match found, or `None` if the filesystem root is
+    reached without one.
+    """
+    current = start.resolve()
+    while True:
+        for name in ENGINE_YAML_NAMES:
+            candidate = current / name
+            if candidate.is_file():
+                return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def find_pyproject(start: Path) -> Path | None:
+    """Walk up from `start` looking for `pyproject.toml`."""
+    current = start.resolve()
+    while True:
+        candidate = current / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+class UvProject:
+    """A `uv` project rooted at a `pyproject.toml`, with awareness of the
+    `engine.yaml` it backs and whether that pairing is embedded or standalone."""
+
+    root: Path
+    """Directory containing `pyproject.toml`."""
+    mode: UvMode
+    engine_yaml: Path
+
+    def __init__(self, *, root: Path, mode: UvMode, engine_yaml: Path) -> None:
+        self.root = root
+        self.mode = mode
+        self.engine_yaml = engine_yaml
+
+    @classmethod
+    def locate(cls, start: Path) -> UvProject:
+        """Locate the uv project backing the `engine.yaml` discovered from `start`.
+
+        Walks up for `engine.yaml`, then walks up from that directory for
+        `pyproject.toml`. If found, embedded mode rooted at the pyproject's
+        directory; otherwise standalone mode rooted alongside `engine.yaml`.
+
+        Raises `EngineYamlNotFound` if no `engine.yaml` is reachable.
+        """
+        engine_yaml = find_engine_yaml(start)
+        if engine_yaml is None:
+            raise EngineYamlNotFound(
+                f"No engine.yaml found at or above {start!s}. "
+                f"Run `wengine init` to create one."
+            )
+        pyproject = find_pyproject(engine_yaml.parent)
+        if pyproject is not None:
+            return cls(root=pyproject.parent, mode="embedded", engine_yaml=engine_yaml)
+        return cls(root=engine_yaml.parent, mode="standalone", engine_yaml=engine_yaml)
+
+    def ensure_pyproject(self) -> None:
+        """Write a minimal `pyproject.toml` in standalone mode if missing.
+
+        No-op in embedded mode — the host project already owns its file.
+        """
+        if self.mode == "embedded":
+            return
+        path = self.root / "pyproject.toml"
+        if path.exists():
+            return
+        path.write_text(_MINIMAL_PYPROJECT)
+
+    def add(self, args: Sequence[str]) -> None:
+        """Run `uv add <args>` in this project."""
+        self.ensure_pyproject()
+        _run_uv(["add", *args], cwd=self.root)
+
+    def remove(self, name: str) -> None:
+        """Run `uv remove <name>` in this project."""
+        _run_uv(["remove", name], cwd=self.root)
+
+    def sync(self) -> None:
+        """Run `uv sync` in this project."""
+        _run_uv(["sync"], cwd=self.root)
+
+
+def _run_uv(args: Sequence[str], *, cwd: Path) -> None:
+    """Invoke `uv` with the given args in `cwd`. Tests monkeypatch this.
+
+    stdout/stderr are inherited so users see uv's progress live. A non-zero
+    exit raises `subprocess.CalledProcessError`.
+    """
+    subprocess.run(["uv", *args], cwd=cwd, check=True)
+
+
+__all__ = [
+    "ENGINE_YAML_NAMES",
+    "EngineYamlNotFound",
+    "UvMode",
+    "UvProject",
+    "find_engine_yaml",
+    "find_pyproject",
+]

--- a/src/workflow_engine/cli/uv_project.py
+++ b/src/workflow_engine/cli/uv_project.py
@@ -115,8 +115,12 @@ class UvProject:
         if self.mode == "embedded":
             return
         path = self.root / "pyproject.toml"
-        if path.exists():
+        if path.is_file():
             return
+        if path.exists():
+            raise RuntimeError(
+                f"Invalid standalone uv project state: {path!s} exists but is not a file."
+            )
         path.write_text(_MINIMAL_PYPROJECT)
 
     def add(self, args: Sequence[str]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,7 @@ node registry, so anything declared here is available to every test file
 without needing to be re-imported.
 """
 
-from pathlib import Path
-from typing import Callable, ClassVar, Type
+from typing import ClassVar, Type
 
 import pytest
 from overrides import override
@@ -25,6 +24,12 @@ from workflow_engine import (
 )
 from workflow_engine.execution import TopologicalExecutionAlgorithm
 from workflow_engine.execution.parallel import ParallelExecutionAlgorithm
+
+# Fixture modules registered project-wide. Add new fixture files here rather
+# than letting this conftest sprawl.
+pytest_plugins = [
+    "tests.fixtures.filesystem",
+]
 
 
 @pytest.fixture(params=["topological", "parallel"])
@@ -79,33 +84,6 @@ class YieldingNode(Node[Empty, SimpleOutput, Params]):
     ) -> SimpleOutput:
         YieldingNode.calls[self.id] = YieldingNode.calls.get(self.id, 0) + 1
         raise ShouldYield(self.message)
-
-
-@pytest.fixture
-def confine_is_file_to(monkeypatch) -> Callable[[Path], None]:
-    """Confine `Path.is_file()` to a subtree, hiding everything outside it.
-
-    CLI helpers that walk up the filesystem looking for marker files
-    (`engine.yaml`, `pyproject.toml`, ...) ascend all the way to the root, so
-    a stray file in a real parent directory (e.g. `/tmp` or a CI home dir) can
-    make "not found" assertions flaky. Call the returned function with a root
-    (typically `tmp_path`): paths at or below it delegate to the real
-    `is_file`, everything else reports `False`.
-    """
-    real_is_file = Path.is_file
-
-    def confine(root: Path) -> None:
-        resolved_root = root.resolve()
-
-        def fake(self: Path) -> bool:
-            resolved = self.resolve()
-            if resolved != resolved_root and resolved_root not in resolved.parents:
-                return False
-            return real_is_file(self)
-
-        monkeypatch.setattr(Path, "is_file", fake)
-
-    return confine
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ node registry, so anything declared here is available to every test file
 without needing to be re-imported.
 """
 
-from typing import ClassVar, Type
+from pathlib import Path
+from typing import Callable, ClassVar, Type
 
 import pytest
 from overrides import override
@@ -78,6 +79,33 @@ class YieldingNode(Node[Empty, SimpleOutput, Params]):
     ) -> SimpleOutput:
         YieldingNode.calls[self.id] = YieldingNode.calls.get(self.id, 0) + 1
         raise ShouldYield(self.message)
+
+
+@pytest.fixture
+def confine_is_file_to(monkeypatch) -> Callable[[Path], None]:
+    """Confine `Path.is_file()` to a subtree, hiding everything outside it.
+
+    CLI helpers that walk up the filesystem looking for marker files
+    (`engine.yaml`, `pyproject.toml`, ...) ascend all the way to the root, so
+    a stray file in a real parent directory (e.g. `/tmp` or a CI home dir) can
+    make "not found" assertions flaky. Call the returned function with a root
+    (typically `tmp_path`): paths at or below it delegate to the real
+    `is_file`, everything else reports `False`.
+    """
+    real_is_file = Path.is_file
+
+    def confine(root: Path) -> None:
+        resolved_root = root.resolve()
+
+        def fake(self: Path) -> bool:
+            resolved = self.resolve()
+            if resolved != resolved_root and resolved_root not in resolved.parents:
+                return False
+            return real_is_file(self)
+
+        monkeypatch.setattr(Path, "is_file", fake)
+
+    return confine
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/filesystem.py
+++ b/tests/fixtures/filesystem.py
@@ -1,0 +1,40 @@
+"""Filesystem-related test fixtures.
+
+Wired into the test session via `pytest_plugins` in the top-level
+`tests/conftest.py`, so every fixture here is available project-wide as if it
+were defined in `conftest.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+
+@pytest.fixture
+def confine_is_file_to(monkeypatch) -> Callable[[Path], None]:
+    """Confine `Path.is_file()` to a subtree, hiding everything outside it.
+
+    CLI helpers that walk up the filesystem looking for marker files
+    (`engine.yaml`, `pyproject.toml`, ...) ascend all the way to the root, so
+    a stray file in a real parent directory (e.g. `/tmp` or a CI home dir) can
+    make "not found" assertions flaky. Call the returned function with a root
+    (typically `tmp_path`): paths at or below it delegate to the real
+    `is_file`, everything else reports `False`.
+    """
+    real_is_file = Path.is_file
+
+    def confine(root: Path) -> None:
+        resolved_root = root.resolve()
+
+        def fake(self: Path) -> bool:
+            resolved = self.resolve()
+            if resolved != resolved_root and resolved_root not in resolved.parents:
+                return False
+            return real_is_file(self)
+
+        monkeypatch.setattr(Path, "is_file", fake)
+
+    return confine

--- a/tests/test_uv_project.py
+++ b/tests/test_uv_project.py
@@ -38,7 +38,8 @@ class TestFindEngineYaml:
         assert result is not None
         assert result.name == "engine.yaml"
 
-    def test_returns_none_if_missing(self, tmp_path: Path):
+    def test_returns_none_if_missing(self, tmp_path: Path, confine_is_file_to):
+        confine_is_file_to(tmp_path)
         assert find_engine_yaml(tmp_path) is None
 
 
@@ -53,8 +54,8 @@ class TestFindPyproject:
         nested.mkdir(parents=True)
         assert find_pyproject(nested) == (tmp_path / "pyproject.toml").resolve()
 
-    def test_returns_none_if_missing(self, tmp_path: Path):
-        # tmp_path is somewhere under /tmp — no pyproject above it.
+    def test_returns_none_if_missing(self, tmp_path: Path, confine_is_file_to):
+        confine_is_file_to(tmp_path)
         assert find_pyproject(tmp_path) is None
 
 

--- a/tests/test_uv_project.py
+++ b/tests/test_uv_project.py
@@ -1,0 +1,191 @@
+"""Tests for `wengine` uv-project discovery and shell-out."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from workflow_engine.cli import uv_project as uv_project_module
+from workflow_engine.cli.uv_project import (
+    EngineYamlNotFound,
+    UvProject,
+    find_engine_yaml,
+    find_pyproject,
+)
+
+
+class TestFindEngineYaml:
+    def test_in_start_dir(self, tmp_path: Path):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        assert find_engine_yaml(tmp_path) == (tmp_path / "engine.yaml").resolve()
+
+    def test_yml_variant(self, tmp_path: Path):
+        (tmp_path / "engine.yml").write_text("nodes: {}\n")
+        assert find_engine_yaml(tmp_path) == (tmp_path / "engine.yml").resolve()
+
+    def test_walks_up(self, tmp_path: Path):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        assert find_engine_yaml(nested) == (tmp_path / "engine.yaml").resolve()
+
+    def test_yaml_preferred_over_yml(self, tmp_path: Path):
+        # If both exist in the same dir, .yaml wins (matches tuple order).
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        (tmp_path / "engine.yml").write_text("nodes: {}\n")
+        result = find_engine_yaml(tmp_path)
+        assert result is not None
+        assert result.name == "engine.yaml"
+
+    def test_returns_none_if_missing(self, tmp_path: Path):
+        assert find_engine_yaml(tmp_path) is None
+
+
+class TestFindPyproject:
+    def test_in_start_dir(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        assert find_pyproject(tmp_path) == (tmp_path / "pyproject.toml").resolve()
+
+    def test_walks_up(self, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        assert find_pyproject(nested) == (tmp_path / "pyproject.toml").resolve()
+
+    def test_returns_none_if_missing(self, tmp_path: Path):
+        # tmp_path is somewhere under /tmp — no pyproject above it.
+        assert find_pyproject(tmp_path) is None
+
+
+class TestUvProjectLocate:
+    def test_embedded_same_dir(self, tmp_path: Path):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+
+        proj = UvProject.locate(tmp_path)
+        assert proj.mode == "embedded"
+        assert proj.root == tmp_path.resolve()
+        assert proj.engine_yaml == (tmp_path / "engine.yaml").resolve()
+
+    def test_embedded_pyproject_above_engine_yaml(self, tmp_path: Path):
+        # engine.yaml deeper than pyproject.toml — still embedded, root at
+        # the pyproject's dir.
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        subdir = tmp_path / "engine"
+        subdir.mkdir()
+        (subdir / "engine.yaml").write_text("nodes: {}\n")
+
+        proj = UvProject.locate(subdir)
+        assert proj.mode == "embedded"
+        assert proj.root == tmp_path.resolve()
+        assert proj.engine_yaml == (subdir / "engine.yaml").resolve()
+
+    def test_standalone(self, tmp_path: Path, monkeypatch):
+        # engine.yaml with no pyproject.toml anywhere above it. Stub
+        # find_pyproject so the result doesn't depend on ambient state
+        # (e.g. a pyproject.toml in /home/<user>).
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        monkeypatch.setattr(uv_project_module, "find_pyproject", lambda _s: None)
+
+        proj = UvProject.locate(tmp_path)
+        assert proj.mode == "standalone"
+        assert proj.root == tmp_path.resolve()
+
+    def test_raises_when_no_engine_yaml(self, tmp_path: Path):
+        with pytest.raises(EngineYamlNotFound, match=r"No engine\.yaml"):
+            UvProject.locate(tmp_path)
+
+
+class TestEnsurePyproject:
+    def test_standalone_writes_minimal(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        # Force standalone regardless of ambient parent pyproject files.
+        monkeypatch.setattr(uv_project_module, "find_pyproject", lambda _start: None)
+
+        proj = UvProject.locate(tmp_path)
+        assert proj.mode == "standalone"
+        proj.ensure_pyproject()
+
+        content = (tmp_path / "pyproject.toml").read_text()
+        assert "[project]" in content
+        assert 'name = "wengine-nodes"' in content
+        assert "dependencies = []" in content
+
+    def test_standalone_does_not_overwrite(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        monkeypatch.setattr(uv_project_module, "find_pyproject", lambda _start: None)
+
+        proj = UvProject.locate(tmp_path)
+        # User-written pyproject (locate didn't see it because find_pyproject
+        # was stubbed). ensure_pyproject must not clobber it.
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'user-file'\n")
+        proj.ensure_pyproject()
+        assert "user-file" in (tmp_path / "pyproject.toml").read_text()
+
+    def test_embedded_is_noop(self, tmp_path: Path):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'host'\n")
+
+        proj = UvProject.locate(tmp_path)
+        assert proj.mode == "embedded"
+        proj.ensure_pyproject()  # must not touch the host's file
+        assert "host" in (tmp_path / "pyproject.toml").read_text()
+
+
+class _RecordedUvCall:
+    def __init__(self, args: list[str], cwd: Path) -> None:
+        self.args = args
+        self.cwd = cwd
+
+
+def _patch_run_uv(monkeypatch) -> list[_RecordedUvCall]:
+    calls: list[_RecordedUvCall] = []
+
+    def fake(args, *, cwd: Path) -> None:
+        calls.append(_RecordedUvCall(list(args), cwd))
+
+    monkeypatch.setattr(uv_project_module, "_run_uv", fake)
+    return calls
+
+
+class TestUvCommands:
+    def test_add_passes_args_through(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        calls = _patch_run_uv(monkeypatch)
+
+        proj = UvProject.locate(tmp_path)
+        proj.add(["acme-scrapers==1.4.0"])
+
+        assert len(calls) == 1
+        assert calls[0].args == ["add", "acme-scrapers==1.4.0"]
+        assert calls[0].cwd == tmp_path.resolve()
+
+    def test_add_in_standalone_ensures_pyproject(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        monkeypatch.setattr(uv_project_module, "find_pyproject", lambda _s: None)
+        _patch_run_uv(monkeypatch)
+
+        proj = UvProject.locate(tmp_path)
+        assert proj.mode == "standalone"
+        assert not (tmp_path / "pyproject.toml").exists()
+
+        proj.add(["acme-scrapers"])
+        assert (tmp_path / "pyproject.toml").exists()
+
+    def test_remove(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        calls = _patch_run_uv(monkeypatch)
+
+        UvProject.locate(tmp_path).remove("acme-scrapers")
+        assert calls[0].args == ["remove", "acme-scrapers"]
+
+    def test_sync(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("nodes: {}\n")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        calls = _patch_run_uv(monkeypatch)
+
+        UvProject.locate(tmp_path).sync()
+        assert calls[0].args == ["sync"]


### PR DESCRIPTION
## Summary

PR 3 of the node-distribution series (`docs/plans/node-distribution.md`).

- `find_engine_yaml(start)` / `find_pyproject(start)` — walk-up discovery.
- `UvProject.locate(start)` — finds `engine.yaml` first, then walks up from there for `pyproject.toml`. If found, **embedded** mode rooted at the pyproject's dir. Otherwise **standalone** mode rooted alongside `engine.yaml`.
- `UvProject.add(args)` / `remove(name)` / `sync()` — shell out to `uv`. stdout/stderr are inherited so users see progress live; non-zero exits raise `CalledProcessError`.
- `UvProject.ensure_pyproject()` — in standalone mode, writes a minimal `pyproject.toml` next to `engine.yaml` on first install. No-op in embedded mode.
- Subprocess invocation goes through a module-private `_run_uv` which tests monkeypatch (no injected runner in the public API).

## What this PR does *not* do

- Does not mutate `engine.yaml`. PR 5's two-phase install handles the entry-point collection and `nodes:` merge.
- No CLI command exposes this yet (`wengine install` lands in PR 5).
- Embedded discovery walks up for **any** `pyproject.toml`, even one that isn't a uv project. uv itself errors on `uv add` against a non-uv pyproject, which is the right surface for the failure.

Walk-up for `engine.yaml` was originally scoped to PR 1 but deliberately deferred — it belongs with the CLI consumer that needs it.

## Test plan

- [x] `uv run pytest tests/test_uv_project.py` — 19 tests covering walk-up discovery, both modes, `ensure_pyproject` no-overwrite, all three commands
- [x] Full suite passes (560 tests)
- [x] `ruff check` / `ruff format` / `pyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)