### PR TITLE
feat: wengine init

### DIFF
--- a/docs/plans/node-distribution.md
+++ b/docs/plans/node-distribution.md
@@ -57,7 +57,7 @@ in the sections below):
 ```sh
 wengine init                                                                    # creates engine.yaml + a pyproject.toml to install into
 wengine install acme-scrapers --only HttpFetch --only HtmlExtract --only Screenshot
-wengine install github:acme/iteration@v2.0.0 --only ForEachV2 --as ForEach       # override the builtin ForEach with a git-hosted node
+wengine install github:acme/iteration@v2.0.0 --only ForEachV2 --as ForEach --force  # override the builtin ForEach (an explicit entry → needs --force)
 wengine install ./vendor/internal-nodes                                          # mount every node it exposes, bare
 wengine install legacy-nodes --prefix vendor/legacy                              # its node names collide with builtins → namespace the whole bundle
 ```
@@ -68,9 +68,12 @@ Resulting `engine.yaml` (the operator's name map):
 schema_version: 1
 
 nodes:
+  # one explicit entry per builtin, seeded by `wengine init` (elided here):
+  #   Add: aceteam-workflow-engine:Add
+  #   ForEach: aceteam-workflow-engine:ForEach   # (overridden below)
+  #   ... etc
   "*":
-    - aceteam-workflow-engine # seeded by `wengine init`
-    - internal-nodes # `wengine install ./vendor/internal-nodes`
+    - internal-nodes # `wengine install ./vendor/internal-nodes` → bulk install appends to the catch-all
   HttpFetch: acme-scrapers:HttpFetch # the three `--only` installs → explicit entries
   HtmlExtract: acme-scrapers:HtmlExtract
   Screenshot: acme-scrapers:Screenshot
@@ -261,7 +264,7 @@ schema_version: 1
 
 nodes: # recognized name → entry-point ref
   "*": # glob: mount every node these distributions expose, under its bare name
-    - aceteam-workflow-engine # this is what `wengine init` seeds
+    - aceteam-workflow-engine # builtins, written here as a hand-authored catch-all (`wengine init` instead emits one explicit entry per builtin)
     - acme-scrapers # stacked on; fine as long as their node names don't collide
   ForEach: acme-iteration:ForEachV2 # explicit: shadow whatever `ForEach` a glob would supply, with the node `acme-iteration` exposes under entry-point name `ForEachV2`
   "vendor/legacy:*": legacy-nodes # prefixed glob: only needed to keep a colliding bundle around — mounts its nodes under vendor/legacy:<Name>
@@ -292,12 +295,12 @@ Glob keys come in two forms, and the plain one is the norm:
   situation: you want to keep a bundle wholesale despite a name clash on the `"*"`
   list and don't want to enumerate explicit entries. It is not the default.
 
-`wengine init` writes `nodes: { "*": [aceteam-workflow-engine] }`. To run a curated
-subset of builtins, replace that with explicit entries for the nodes you want —
-there is no `disable:` list (an explicit entry can only _add_ or _shadow_, not
-subtract; the way you subtract is by not putting the distribution on the `"*"`
-list). `wengine init --explicit` expands the catch-all into one explicit entry per
-builtin so you can delete lines.
+`wengine init` writes one explicit entry per builtin (`Name: aceteam-workflow-engine:Name`),
+not a `"*"` glob — the seeded map states exactly what is mounted, and curating a
+subset is then deleting lines. There is no `disable:` list (an explicit entry can
+only _add_ or _shadow_, not subtract; you subtract by deleting the entry). The
+`"*"` glob form stays valid for anyone who prefers to hand-write a catch-all over
+a distribution, but it is not what `init` emits.
 
 ### Node-source package: `[project.entry-points."aceteam_workflow_engine.nodes"]`
 
@@ -381,7 +384,7 @@ and list `nodeName = "module:NodeClass [extras]"` for each node. Notes:
 ```sh
 wengine install <target> [--only <NodeName> ...] [--as <name>] [--prefix <p>] [--force]
 wengine install            # no target: sync the environment to uv.lock + re-apply the name map
-wengine init [--explicit]  # create engine.yaml (and, standalone, pyproject.toml)
+wengine init               # create engine.yaml (and, standalone, pyproject.toml)
 ```
 
 `<target>` is anything `uv add` accepts, plus two shorthands:
@@ -398,7 +401,7 @@ wengine init [--explicit]  # create engine.yaml (and, standalone, pyproject.toml
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | _(none)_            | Append the distribution to the `"*"` list — mount all its nodes bare, and request the union of their declared extras. If a bare name would collide, the install errors and points you at `--only` / `--prefix`. |
 | `--only <NodeName>` | Write an explicit entry for just that node instead of touching the `"*"` list, and request only that node's declared extras (repeatable).                                                                       |
-| `--as <name>`       | The recognized name an `--only` node maps to (only valid with a single `--only`). Defaults to the entry-point name. Use it to rename-on-install (e.g. `--only ForEachV2 --as ForEach` to override the builtin). |
+| `--as <name>`       | The recognized name an `--only` node maps to (only valid with a single `--only`). Defaults to the entry-point name. Use it to rename-on-install (e.g. `--only ForEachV2 --as ForEach --force` to override the builtin — since `init` seeds builtins as explicit entries, this is an explicit-vs-explicit clash and needs `--force`). |
 | `--prefix <p>`      | Write a `"<p>:*"` glob instead of touching the `"*"` list — mount the whole bundle under `<p>:<Name>` (with the union of its nodes' extras). The collision escape hatch.                                        |
 | `--force`           | Overwrite an existing explicit `nodes:` entry that points at a different distribution. Without it, such a clash is an error.                                                                                    |
 
@@ -437,9 +440,11 @@ engine project:
    installed (every node, for a bulk / `--prefix` install; just the `--only` ones
    otherwise).
 3. **Check the merged map.** Combine the proposed mappings with the existing
-   `engine.yaml`. A new explicit entry that shadows a glob (e.g. overriding a
-   builtin) is fine. A new explicit entry that collides with an existing _explicit_
-   entry for a different distribution is an error unless `--force`. A bare name that
+   `engine.yaml`. A new explicit entry that shadows a glob is fine. A new explicit
+   entry that collides with an existing _explicit_ entry for a different distribution
+   is an error unless `--force` — this includes overriding a builtin, since `init`
+   seeds builtins as explicit entries (so `--as ForEach` over the seeded `ForEach`
+   needs `--force`). A bare name that
    two glob-mounted distributions would both supply, with no explicit entry to
    disambiguate, is a hard error — abort before touching anything. (This is why
    step 2 reads all the relevant entry-point tables before installing.)
@@ -450,9 +455,10 @@ engine project:
 5. Apply the `engine.yaml` change from step 2 (append to the `"*"` list, or write
    the explicit / `prefix:*` entries).
 
-`wengine init` creates `engine.yaml` with `nodes: { "*": [aceteam-workflow-engine] }`
-(and, in standalone mode, a minimal `pyproject.toml` declaring `aceteam-workflow-engine`
-as a dependency, then runs `uv sync`). `wengine install` with no target runs `uv sync`
+`wengine init` creates `engine.yaml` with one explicit entry per builtin (and, in
+standalone mode, a minimal `pyproject.toml` declaring `aceteam-workflow-engine`
+as a dependency, then runs `uv add aceteam-workflow-engine` to resolve and lock
+it). `wengine install` with no target runs `uv sync`
 and re-derives the registry from `engine.yaml` — the "reconstruct the environment
 from the lockfile" operation, for a fresh checkout or CI.
 
@@ -495,8 +501,8 @@ engine.yaml.nodes[<name>]   →   error
 ```
 
 There is no implicit builtin fallback — if `aceteam-workflow-engine`'s nodes are
-wanted, they are in `engine.yaml` (on the `"*"` list that `wengine init` seeds, or
-as explicit entries). When more than one `nodes:` entry could supply a name,
+wanted, they are in `engine.yaml` (the explicit entries `wengine init` seeds, or
+a hand-authored `"*"` list). When more than one `nodes:` entry could supply a name,
 precedence is **explicit entry > glob entry**; two glob-mounted distributions
 supplying the same bare name is the install-time error described above (and
 `prefix:*` mounts live in their own `prefix:`-keyed space, so they never collide
@@ -568,7 +574,7 @@ thing to add; for now a workflow is interpreted relative to one engine, and
    two-phase install (collect entry-point tables of all affected distributions →
    merge with `engine.yaml` → reject unresolved bare-name collisions among
    glob-mounted distributions → `uv add` → write `nodes:` entries). `wengine init`
-   seeds `nodes: { "*": [aceteam-workflow-engine] }`.
+   seeds one explicit entry per builtin.
 6. **Loader integration** — populate the process node registry from the project's
    `nodes:` map (precedence: explicit entry > glob; bare-name collisions among globs
    are errors), import-and-pull the class lazily on first use, fatal error if the
@@ -592,7 +598,7 @@ Chosen over alternatives; the body above has the reasoning.
   line equal to the union of its still-mapped nodes' extras. Recommended: one extra
   per node, named after it.
 - **Builtins are not special** — `aceteam-workflow-engine`'s nodes are entry points
-  like any others; `wengine init` just seeds the `"*"` glob that mounts them.
+  like any others; `wengine init` seeds one explicit entry per builtin that mounts them.
 - **Two modes** — embedded (operator's existing `uv` project _is_ the engine env) and
   standalone (`wengine init` creates one beside `engine.yaml`).
 - **`uv.lock` committed, environment not** — `uv sync` (or `wengine install` with no

--- a/src/workflow_engine/cli/engine_init.py
+++ b/src/workflow_engine/cli/engine_init.py
@@ -1,0 +1,104 @@
+"""Create a fresh engine project — the `wengine init` machinery.
+
+`wengine init` writes an `engine.yaml` whose name map mounts the builtin nodes,
+and (in standalone mode) sets up the `uv` project that backs it. See
+docs/plans/node-distribution.md.
+
+The filesystem effects (writing `engine.yaml`, the minimal `pyproject.toml`)
+are separated from the `uv` shell-out, which goes through `UvProject` / the
+module-private `_run_uv` that tests monkeypatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import yaml
+
+from workflow_engine.core.config import _iter_node_entry_points
+
+from .uv_project import ENGINE_YAML_NAMES, UvProject
+
+# The engine's own distribution. Builtins are advertised through the same
+# entry-point group as third-party packages (see the trust model in the design
+# doc); `wengine init` seeds the `"*"` glob that mounts them.
+BUILTIN_DISTRIBUTION = "aceteam-workflow-engine"
+
+
+class EngineYamlAlreadyExists(FileExistsError):
+    """Raised when `wengine init` finds an `engine.yaml` already in the target dir."""
+
+
+def builtin_entry_point_names() -> tuple[str, ...]:
+    """The node entry-point names the engine's own distribution advertises.
+
+    Read from `wengine`'s own environment — the builtins live in the same
+    distribution `wengine` itself ships in, so this is the right source even
+    before the target project's environment is provisioned.
+    """
+    return tuple(
+        sorted(ep.name for ep in _iter_node_entry_points(BUILTIN_DISTRIBUTION))
+    )
+
+
+def initial_nodes_config(*, explicit: bool) -> Mapping[str, str | Sequence[str]]:
+    """The `nodes:` block a fresh `engine.yaml` starts with.
+
+    By default a single `"*"` glob mounting every builtin under its bare name.
+    With `explicit=True`, one explicit `Name: <dist>:<Name>` entry per builtin,
+    so an operator can curate by deleting lines.
+    """
+    if not explicit:
+        return {"*": [BUILTIN_DISTRIBUTION]}
+    return {
+        name: f"{BUILTIN_DISTRIBUTION}:{name}" for name in builtin_entry_point_names()
+    }
+
+
+def render_engine_yaml(nodes: Mapping[str, str | Sequence[str]]) -> str:
+    """Render a full `engine.yaml` document for the given `nodes:` block."""
+    return yaml.safe_dump(
+        {"schema_version": 1, "nodes": dict(nodes)},
+        sort_keys=False,
+        default_flow_style=False,
+    )
+
+
+def init_engine_project(target_dir: Path, *, explicit: bool = False) -> Path:
+    """Initialize a new engine project rooted at `target_dir`.
+
+    Writes `engine.yaml`, then sets up the backing `uv` project: in standalone
+    mode (no enclosing `pyproject.toml`) it writes a minimal one and `uv add`s
+    the engine distribution; in embedded mode the host project already owns its
+    dependencies, so only `engine.yaml` is written.
+
+    Returns the path to the written `engine.yaml`. Raises
+    `EngineYamlAlreadyExists` if `target_dir` already contains one.
+    """
+    target_dir = target_dir.resolve()
+    for name in ENGINE_YAML_NAMES:
+        if (target_dir / name).exists():
+            raise EngineYamlAlreadyExists(
+                f"{target_dir / name} already exists; refusing to overwrite. "
+                f"Edit it by hand, or remove it to re-init."
+            )
+
+    engine_yaml = target_dir / ENGINE_YAML_NAMES[0]
+    engine_yaml.write_text(render_engine_yaml(initial_nodes_config(explicit=explicit)))
+
+    project = UvProject.locate(target_dir)
+    if project.mode == "standalone":
+        project.add([BUILTIN_DISTRIBUTION])
+
+    return engine_yaml
+
+
+__all__ = [
+    "BUILTIN_DISTRIBUTION",
+    "EngineYamlAlreadyExists",
+    "builtin_entry_point_names",
+    "init_engine_project",
+    "initial_nodes_config",
+    "render_engine_yaml",
+]

--- a/src/workflow_engine/cli/engine_init.py
+++ b/src/workflow_engine/cli/engine_init.py
@@ -22,7 +22,7 @@ from .uv_project import ENGINE_YAML_NAMES, UvProject
 
 # The engine's own distribution. Builtins are advertised through the same
 # entry-point group as third-party packages (see the trust model in the design
-# doc); `wengine init` seeds the `"*"` glob that mounts them.
+# doc); fresh `engine.yaml` files seed one explicit entry per builtin.
 BUILTIN_DISTRIBUTION = "aceteam-workflow-engine"
 
 

--- a/src/workflow_engine/cli/engine_init.py
+++ b/src/workflow_engine/cli/engine_init.py
@@ -42,15 +42,14 @@ def builtin_entry_point_names() -> tuple[str, ...]:
     )
 
 
-def initial_nodes_config(*, explicit: bool) -> Mapping[str, str | Sequence[str]]:
+def initial_nodes_config() -> Mapping[str, str]:
     """The `nodes:` block a fresh `engine.yaml` starts with.
 
-    By default a single `"*"` glob mounting every builtin under its bare name.
-    With `explicit=True`, one explicit `Name: <dist>:<Name>` entry per builtin,
-    so an operator can curate by deleting lines.
+    One explicit `Name: <dist>:<Name>` entry per builtin. We seed explicit
+    entries rather than a `"*"` glob so the name map states exactly what is
+    mounted — curating is then deleting lines. The glob form stays valid in the
+    schema for anyone who prefers to hand-write it.
     """
-    if not explicit:
-        return {"*": [BUILTIN_DISTRIBUTION]}
     return {
         name: f"{BUILTIN_DISTRIBUTION}:{name}" for name in builtin_entry_point_names()
     }
@@ -65,7 +64,7 @@ def render_engine_yaml(nodes: Mapping[str, str | Sequence[str]]) -> str:
     )
 
 
-def init_engine_project(target_dir: Path, *, explicit: bool = False) -> Path:
+def init_engine_project(target_dir: Path) -> Path:
     """Initialize a new engine project rooted at `target_dir`.
 
     Writes `engine.yaml`, then sets up the backing `uv` project: in standalone
@@ -85,7 +84,7 @@ def init_engine_project(target_dir: Path, *, explicit: bool = False) -> Path:
             )
 
     engine_yaml = target_dir / ENGINE_YAML_NAMES[0]
-    engine_yaml.write_text(render_engine_yaml(initial_nodes_config(explicit=explicit)))
+    engine_yaml.write_text(render_engine_yaml(initial_nodes_config()))
 
     project = UvProject.locate(target_dir)
     if project.mode == "standalone":

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -17,6 +17,7 @@ import platformdirs
 import yaml
 
 from workflow_engine import __version__
+from workflow_engine.cli.engine_init import EngineYamlAlreadyExists, init_engine_project
 from workflow_engine.contexts.local import LocalContext
 from workflow_engine.core.config import WorkflowEngineConfig
 from workflow_engine.core.context import ValidationContext
@@ -148,6 +149,25 @@ config_option = click.option(
 @click.version_option(__version__, prog_name="wengine")
 def cli():
     """Workflow Engine CLI."""
+
+
+# ---------- init ----------
+
+
+@cli.command("init")
+@click.option(
+    "--explicit",
+    is_flag=True,
+    help="Seed one explicit entry per builtin node instead of a '*' glob, "
+    "so you can curate the set by deleting lines.",
+)
+def init_cmd(explicit: bool):
+    """Create an engine.yaml (and, standalone, a pyproject.toml) here."""
+    try:
+        engine_yaml = init_engine_project(Path.cwd(), explicit=explicit)
+    except EngineYamlAlreadyExists as e:
+        raise click.ClickException(str(e)) from e
+    click.echo(f"Created {engine_yaml}")
 
 
 # ---------- config ----------

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -155,16 +155,10 @@ def cli():
 
 
 @cli.command("init")
-@click.option(
-    "--explicit",
-    is_flag=True,
-    help="Seed one explicit entry per builtin node instead of a '*' glob, "
-    "so you can curate the set by deleting lines.",
-)
-def init_cmd(explicit: bool):
+def init_cmd():
     """Create an engine.yaml (and, standalone, a pyproject.toml) here."""
     try:
-        engine_yaml = init_engine_project(Path.cwd(), explicit=explicit)
+        engine_yaml = init_engine_project(Path.cwd())
     except EngineYamlAlreadyExists as e:
         raise click.ClickException(str(e)) from e
     click.echo(f"Created {engine_yaml}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,17 +958,29 @@ class TestWorkflowEdit:
 
 
 class TestInit:
-    def test_creates_engine_yaml(self, runner: CliRunner, monkeypatch):
+    def test_creates_engine_yaml(
+        self, runner: CliRunner, monkeypatch, confine_is_file_to
+    ):
         # Standalone init shells out to `uv add`; stub it so the test stays
-        # offline and deterministic.
+        # offline and deterministic, while still proving we exercised the
+        # standalone path.
         from workflow_engine.cli import uv_project as uv_project_module
 
-        monkeypatch.setattr(uv_project_module, "_run_uv", lambda *a, **k: None)
+        uv_calls = []
+
+        def fake_run_uv(*args, **kwargs):
+            uv_calls.append((args, kwargs))
+            return None
+
+        monkeypatch.setattr(uv_project_module, "_run_uv", fake_run_uv)
 
         with runner.isolated_filesystem():
+            confine_is_file_to(Path.cwd())
             result = invoke_cli(runner, "init")
             assert result.exit_code == 0, result.output
             assert "Created" in result.output
+            assert uv_calls, "expected standalone init to invoke uv"
+            assert Path("pyproject.toml").is_file()
             assert Path("engine.yaml").is_file()
 
     def test_refuses_when_engine_yaml_exists(self, runner: CliRunner, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -952,3 +952,32 @@ class TestWorkflowEdit:
         )
         payload = json.loads(populated_workflow.read_text())
         assert payload["edges"] == []
+
+
+# ---------- init ----------
+
+
+class TestInit:
+    def test_creates_engine_yaml(self, runner: CliRunner, monkeypatch):
+        # Standalone init shells out to `uv add`; stub it so the test stays
+        # offline and deterministic.
+        from workflow_engine.cli import uv_project as uv_project_module
+
+        monkeypatch.setattr(uv_project_module, "_run_uv", lambda *a, **k: None)
+
+        with runner.isolated_filesystem():
+            result = invoke_cli(runner, "init")
+            assert result.exit_code == 0, result.output
+            assert "Created" in result.output
+            assert Path("engine.yaml").is_file()
+
+    def test_refuses_when_engine_yaml_exists(self, runner: CliRunner, monkeypatch):
+        from workflow_engine.cli import uv_project as uv_project_module
+
+        monkeypatch.setattr(uv_project_module, "_run_uv", lambda *a, **k: None)
+
+        with runner.isolated_filesystem():
+            Path("engine.yaml").write_text("schema_version: 1\nnodes: {}\n")
+            result = invoke_cli(runner, "init")
+            assert result.exit_code != 0
+            assert "already exists" in result.output

--- a/tests/test_engine_init.py
+++ b/tests/test_engine_init.py
@@ -1,0 +1,126 @@
+"""Tests for `wengine init` — engine.yaml seeding and uv-project setup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from workflow_engine.cli import uv_project as uv_project_module
+from workflow_engine.cli.engine_init import (
+    BUILTIN_DISTRIBUTION,
+    EngineYamlAlreadyExists,
+    builtin_entry_point_names,
+    init_engine_project,
+    initial_nodes_config,
+    render_engine_yaml,
+)
+from workflow_engine.core.config import WorkflowEngineConfig
+
+
+class _RecordedUvCall:
+    def __init__(self, args: list[str], cwd: Path) -> None:
+        self.args = args
+        self.cwd = cwd
+
+
+def _patch_run_uv(monkeypatch) -> list[_RecordedUvCall]:
+    calls: list[_RecordedUvCall] = []
+
+    def fake(args, *, cwd: Path) -> None:
+        calls.append(_RecordedUvCall(list(args), cwd))
+
+    monkeypatch.setattr(uv_project_module, "_run_uv", fake)
+    return calls
+
+
+class TestBuiltinEntryPoints:
+    def test_includes_known_builtins(self):
+        names = builtin_entry_point_names()
+        assert "Input" in names
+        assert "Output" in names
+        assert "Sum" in names
+
+    def test_sorted(self):
+        names = builtin_entry_point_names()
+        assert list(names) == sorted(names)
+
+
+class TestInitialNodesConfig:
+    def test_default_is_global_glob(self):
+        nodes = initial_nodes_config(explicit=False)
+        assert nodes == {"*": [BUILTIN_DISTRIBUTION]}
+
+    def test_explicit_one_entry_per_builtin(self):
+        nodes = initial_nodes_config(explicit=True)
+        assert "*" not in nodes
+        assert nodes["Input"] == f"{BUILTIN_DISTRIBUTION}:Input"
+        assert set(nodes) == set(builtin_entry_point_names())
+
+
+class TestRenderEngineYaml:
+    def test_round_trips_through_config(self):
+        # The rendered document must parse as a valid engine.yaml.
+        text = render_engine_yaml(initial_nodes_config(explicit=False))
+        parsed = yaml.safe_load(text)
+        assert parsed["schema_version"] == 1
+        WorkflowEngineConfig.model_validate(parsed)
+
+    def test_explicit_round_trips(self):
+        text = render_engine_yaml(initial_nodes_config(explicit=True))
+        WorkflowEngineConfig.model_validate(yaml.safe_load(text))
+
+
+class TestInitEngineProject:
+    def test_standalone_writes_yaml_and_adds_engine(
+        self, tmp_path: Path, monkeypatch, confine_is_file_to
+    ):
+        # No pyproject above tmp_path → standalone.
+        confine_is_file_to(tmp_path)
+        calls = _patch_run_uv(monkeypatch)
+
+        engine_yaml = init_engine_project(tmp_path, explicit=False)
+
+        assert engine_yaml == (tmp_path / "engine.yaml").resolve()
+        assert engine_yaml.is_file()
+        # Standalone: a pyproject was written and the engine distribution added.
+        assert (tmp_path / "pyproject.toml").is_file()
+        assert len(calls) == 1
+        assert calls[0].args == ["add", BUILTIN_DISTRIBUTION]
+        assert calls[0].cwd == tmp_path.resolve()
+
+    def test_embedded_writes_yaml_only(self, tmp_path: Path, monkeypatch):
+        # An enclosing pyproject.toml → embedded; init must not touch uv.
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'host'\n")
+        calls = _patch_run_uv(monkeypatch)
+
+        engine_yaml = init_engine_project(tmp_path, explicit=False)
+
+        assert engine_yaml.is_file()
+        assert calls == []
+        # The host's pyproject is untouched.
+        assert "host" in (tmp_path / "pyproject.toml").read_text()
+
+    def test_written_yaml_is_valid_config(
+        self, tmp_path: Path, monkeypatch, confine_is_file_to
+    ):
+        confine_is_file_to(tmp_path)
+        _patch_run_uv(monkeypatch)
+
+        engine_yaml = init_engine_project(tmp_path, explicit=True)
+        WorkflowEngineConfig.load(engine_yaml)
+
+    def test_refuses_existing_yaml(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yaml").write_text("schema_version: 1\nnodes: {}\n")
+        _patch_run_uv(monkeypatch)
+
+        with pytest.raises(EngineYamlAlreadyExists, match="already exists"):
+            init_engine_project(tmp_path)
+
+    def test_refuses_existing_yml_variant(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "engine.yml").write_text("schema_version: 1\nnodes: {}\n")
+        _patch_run_uv(monkeypatch)
+
+        with pytest.raises(EngineYamlAlreadyExists):
+            init_engine_project(tmp_path)

--- a/tests/test_engine_init.py
+++ b/tests/test_engine_init.py
@@ -48,12 +48,8 @@ class TestBuiltinEntryPoints:
 
 
 class TestInitialNodesConfig:
-    def test_default_is_global_glob(self):
-        nodes = initial_nodes_config(explicit=False)
-        assert nodes == {"*": [BUILTIN_DISTRIBUTION]}
-
-    def test_explicit_one_entry_per_builtin(self):
-        nodes = initial_nodes_config(explicit=True)
+    def test_one_explicit_entry_per_builtin(self):
+        nodes = initial_nodes_config()
         assert "*" not in nodes
         assert nodes["Input"] == f"{BUILTIN_DISTRIBUTION}:Input"
         assert set(nodes) == set(builtin_entry_point_names())
@@ -62,14 +58,10 @@ class TestInitialNodesConfig:
 class TestRenderEngineYaml:
     def test_round_trips_through_config(self):
         # The rendered document must parse as a valid engine.yaml.
-        text = render_engine_yaml(initial_nodes_config(explicit=False))
+        text = render_engine_yaml(initial_nodes_config())
         parsed = yaml.safe_load(text)
         assert parsed["schema_version"] == 1
         WorkflowEngineConfig.model_validate(parsed)
-
-    def test_explicit_round_trips(self):
-        text = render_engine_yaml(initial_nodes_config(explicit=True))
-        WorkflowEngineConfig.model_validate(yaml.safe_load(text))
 
 
 class TestInitEngineProject:
@@ -80,7 +72,7 @@ class TestInitEngineProject:
         confine_is_file_to(tmp_path)
         calls = _patch_run_uv(monkeypatch)
 
-        engine_yaml = init_engine_project(tmp_path, explicit=False)
+        engine_yaml = init_engine_project(tmp_path)
 
         assert engine_yaml == (tmp_path / "engine.yaml").resolve()
         assert engine_yaml.is_file()
@@ -95,7 +87,7 @@ class TestInitEngineProject:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'host'\n")
         calls = _patch_run_uv(monkeypatch)
 
-        engine_yaml = init_engine_project(tmp_path, explicit=False)
+        engine_yaml = init_engine_project(tmp_path)
 
         assert engine_yaml.is_file()
         assert calls == []
@@ -108,7 +100,7 @@ class TestInitEngineProject:
         confine_is_file_to(tmp_path)
         _patch_run_uv(monkeypatch)
 
-        engine_yaml = init_engine_project(tmp_path, explicit=True)
+        engine_yaml = init_engine_project(tmp_path)
         WorkflowEngineConfig.load(engine_yaml)
 
     def test_refuses_existing_yaml(self, tmp_path: Path, monkeypatch):


### PR DESCRIPTION
First wired-up command from the node-distribution series (`docs/plans/node-distribution.md`, build-order step 5, carved small).

## What this does

`wengine init`:
- Writes `engine.yaml` with `schema_version: 1` and one **explicit** entry per builtin (`Name: aceteam-workflow-engine:Name`). The seeded map states exactly what is mounted; curating is deleting lines. The `"*"` glob form stays valid in the schema for hand-authoring, but `init` doesn't emit it.
- **Standalone** (no enclosing `pyproject.toml`): writes a minimal `pyproject.toml` via `UvProject` and `uv add`s the engine distribution.
- **Embedded** (an enclosing `pyproject.toml`): writes only `engine.yaml` — the host project already owns its dependencies.

## Structure

- `src/workflow_engine/cli/engine_init.py` — testable pieces (`initial_nodes_config`, `render_engine_yaml`, `builtin_entry_point_names`, `init_engine_project`). The `uv` shell-out reuses `UvProject` / the `_run_uv` monkeypatch seam, so tests stay offline.
- `init` command wired into `main.py`.
- `tests/test_engine_init.py` + `TestInit` in `test_cli.py`.

## Design note

Explicit-by-default has one consequence, now reflected in the design doc: overriding a builtin (e.g. `--as ForEach`) is an explicit-vs-explicit collision and requires `--force`. (The old `"*"`-glob default let explicit entries shadow builtins freely; we chose the more consistent rule.)

## Deferred (next PRs)

- `wengine install` — two-phase install. Includes resolving the **standalone-venv entry-point read** (config.py's `_iter_node_entry_points` reads wengine's own interpreter — correct for embedded, not standalone) and the post-`uv add` collision check (uv has no `--dry-run`/`download`, so validation happens after the add).
- `wengine uninstall`.