### PR TITLE
feat: wengine uninstall

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,18 @@
 
 If no `engine.yaml` is found on the walk up, those commands fail with an error pointing at `wengine init`. Commands that only write a file (`workflow init`) or create the project (`wengine init`) do not require an existing `engine.yaml`. Users edit `engine.yaml` directly — the CLI has no per-key edit operations for it.
 
+### `wengine init`
+
+Creates an `engine.yaml` in the current directory, its `nodes:` map seeded with one explicit entry per built-in node. In standalone mode it also creates the `pyproject.toml` that backs the project's environment. Errors if an `engine.yaml` already exists.
+
+### `wengine install [<target>] [--only NODE]... [--as NAME] [--prefix P] [--force]`
+
+Installs a node-source distribution and maps its nodes into `engine.yaml` (roughly `uv add <target>` plus a name-map edit). `--only` maps just the named node(s); `--as` renames a single `--only` node; `--prefix` mounts the bundle under a `P:<Name>` namespace; `--force` overrides an existing explicit entry. With no `<target>`, it syncs the environment to `uv.lock` (rebuilds a checkout). See docs/plans/node-distribution.md for the full flow.
+
+### `wengine uninstall <name>` / `wengine uninstall --dist <name>`
+
+Removes a node mapping and reconciles `pyproject.toml` — the inverse of `install`. By node name, it drops that name's explicit entry; the distribution stays installed if other entries still reference it (its extras are re-narrowed to the union of the still-mapped nodes), otherwise it is `uv remove`d. `--dist <name>` removes every entry for a distribution at once (explicit entries plus its membership in any glob) and then uninstalls it.
+
 ## `wengine schema`
 
 ### `wengine schema list`

--- a/docs/plans/node-distribution.md
+++ b/docs/plans/node-distribution.md
@@ -469,18 +469,26 @@ themselves. Operators who want a review gate already have one — code review on
 
 ### Uninstalling
 
-`wengine uninstall <NodeName>` removes the `engine.yaml` entry, then reconciles
-`pyproject.toml`:
+`wengine uninstall <NodeName>` removes the `engine.yaml` entry first, then
+reconciles `pyproject.toml`:
 
 - If other nodes from the same distribution are still mapped, it recomputes that
   distribution's extra set — the union of the `[extras]` of the _still-mapped_ nodes
-  — and, if it shrank, runs `uv add <distribution>[<new set>]` (which lets `uv` drop
-  any now-unneeded transitive deps). So uninstalling `Screenshot` rewrites
-  `acme-scrapers[screenshot]` → `acme-scrapers` only if no remaining mapped node
-  needs the `screenshot` extra (or, with a shared `browser` extra, no remaining node
-  needs `browser` — e.g. `CrawlSite` is gone too); `wengine` reads the entry-point
-  tables, so it always knows the answer.
+  — and, if it shrank, rewrites that distribution's `[project.dependencies]` extras
+  to the new set and runs `uv sync` (which lets `uv` drop any now-unneeded transitive
+  deps). So uninstalling `Screenshot` rewrites `acme-scrapers[screenshot]` →
+  `acme-scrapers` only if no remaining mapped node needs the `screenshot` extra (or,
+  with a shared `browser` extra, no remaining node needs `browser` — e.g. `CrawlSite`
+  is gone too); `wengine` reads the entry-point tables, so it always knows the answer.
+  (It edits the dependency line rather than `uv add <distribution>[<new set>]`
+  because `uv add` only _merges_ extras — it has no reset — and `uv remove`+re-add
+  would wipe the distribution's `[tool.uv.sources]` entry; editing the line in place
+  leaves the source mapping untouched and works the same for git/path/PyPI sources.)
 - If no entry references the distribution at all anymore, it runs `uv remove <distribution>`.
+
+`engine.yaml` is rewritten before `pyproject.toml` so that a failed `uv` step
+leaves only superfluous extras behind, never an unmapped-but-still-needed node or
+a removed-but-still-referenced distribution.
 
 A distribution reachable through several `engine.yaml` entries (the `"*"` list plus
 an explicit override, say) needs all of them gone before that last step fires;

--- a/src/workflow_engine/cli/main.py
+++ b/src/workflow_engine/cli/main.py
@@ -18,6 +18,7 @@ import yaml
 from workflow_engine import __version__
 from workflow_engine.cli.engine_init import EngineYamlAlreadyExists, init_engine_project
 from workflow_engine.cli.install import InstallError, install
+from workflow_engine.cli.uninstall import UninstallError, uninstall
 from workflow_engine.cli.uv_project import (
     EngineYamlNotFound,
     UvProject,
@@ -196,6 +197,40 @@ def install_cmd(
     except (InstallError, EngineYamlNotFound) as e:
         raise click.ClickException(str(e)) from e
     click.echo(f"Installed {dist}")
+
+
+# ---------- uninstall ----------
+
+
+@cli.command("uninstall")
+@click.argument("name", required=False)
+@click.option(
+    "--dist",
+    "dist",
+    metavar="NAME",
+    help="Remove every entry for this distribution at once.",
+)
+def uninstall_cmd(name: str | None, dist: str | None):
+    """Remove a mapped node, or (with --dist) a whole distribution.
+
+    `wengine uninstall <NAME>` drops the explicit entry for NAME; the package
+    stays installed if other entries still use it (its extras are re-narrowed).
+    `wengine uninstall --dist <NAME>` removes every entry for a distribution and
+    uninstalls it.
+    """
+    try:
+        result = uninstall(name, dist=dist)
+    except (UninstallError, InstallError, EngineYamlNotFound) as e:
+        raise click.ClickException(str(e)) from e
+    if result.removed_distribution:
+        click.echo(f"Uninstalled {result.distribution}.")
+    elif name is not None:
+        click.echo(
+            f"Unmapped {name} (left {result.distribution} installed; "
+            f"other entries still use it)."
+        )
+    else:
+        click.echo(f"Updated mappings for {result.distribution}.")
 
 
 # ---------- schema ----------

--- a/src/workflow_engine/cli/uninstall.py
+++ b/src/workflow_engine/cli/uninstall.py
@@ -31,12 +31,12 @@ from __future__ import annotations
 
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
 from pathlib import Path
 
 from packaging.requirements import Requirement
 
 from ..core.config import Distribution
+from ..utils.model import ImmutableBaseModel
 from .install import (
     MountedNode,
     NodeEntry,
@@ -53,8 +53,7 @@ class UninstallError(Exception):
     """A `wengine uninstall` failed for an operator-actionable reason."""
 
 
-@dataclass(frozen=True)
-class UninstallResult:
+class UninstallResult(ImmutableBaseModel):
     """What `uninstall` did, for the CLI to report."""
 
     distribution: Distribution

--- a/src/workflow_engine/cli/uninstall.py
+++ b/src/workflow_engine/cli/uninstall.py
@@ -1,0 +1,245 @@
+"""`wengine uninstall` — remove a mapped node, or a whole distribution.
+
+The inverse of `wengine install` (see `install.py`): it edits `engine.yaml` to
+drop a name map, then reconciles `pyproject.toml` to match what is still mapped.
+
+- `wengine uninstall <NodeName>` removes the *explicit* entry for that name. The
+  distribution it pointed at may still be reachable through other entries (other
+  explicit names, or a glob), in which case the package stays installed and only
+  its extras are re-narrowed.
+- `wengine uninstall --dist <name>` removes *every* entry referencing a
+  distribution at once — explicit entries plus its membership in any glob list.
+
+Reconciliation of the distribution `D` whose mapping shrank:
+
+- If any entry still references `D`, recompute the union of the still-mapped
+  nodes' declared extras (a glob keeps every node mapped, so it pins the full
+  set) and, if it shrank, rewrite `D`'s `[project.dependencies]` extras to that
+  set and `uv sync`. `uv` then drops now-unneeded transitive deps. We edit the
+  extras in `pyproject.toml` rather than `uv add D[…]` because `uv add` only
+  *merges* extras (it has no reset), and `uv remove`+re-add would wipe `D`'s
+  `[tool.uv.sources]` entry — editing the dependency line leaves the source
+  mapping untouched and works the same for git/path/workspace/PyPI sources.
+- If nothing references `D` anymore, `uv remove D`.
+
+`engine.yaml` is written *first*, then `pyproject.toml` is reconciled: a failed
+reconcile then leaves only superfluous extras behind (benign), rather than an
+unmapped-but-still-needed node or a removed-but-still-referenced distribution.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+from ..core.config import Distribution
+from .install import (
+    MountedNode,
+    NodeEntry,
+    extras_union,
+    load_nodes_block,
+    read_distribution_entry_points,
+    read_pyproject_dependencies,
+    write_nodes_block,
+)
+from .uv_project import UvProject
+
+
+class UninstallError(Exception):
+    """A `wengine uninstall` failed for an operator-actionable reason."""
+
+
+@dataclass(frozen=True)
+class UninstallResult:
+    """What `uninstall` did, for the CLI to report."""
+
+    distribution: Distribution
+    removed_distribution: bool  # True if `uv remove` ran; False if it stayed.
+
+
+# ---------- pure helpers ----------
+
+
+def _is_glob_key(key: str) -> bool:
+    """Whether a `nodes:` key is a glob (`"*"` or `"<prefix>:*"`)."""
+    return key == "*" or key.endswith(":*")
+
+
+def _glob_dists(value: NodeEntry) -> list[str]:
+    """The distribution list under a glob value (a name or a list of names)."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    raise UninstallError(f"Glob entry has an unexpected value: {value!r}.")
+
+
+def distribution_for_node(nodes: Mapping[str, NodeEntry], name: str) -> Distribution:
+    """The distribution an *explicit* `name` entry points at.
+
+    Raises `UninstallError` if `name` has no explicit entry (it may be supplied
+    by a glob, which can only be removed wholesale with `--dist`).
+    """
+    value = nodes.get(name)
+    if not isinstance(value, str):
+        raise UninstallError(
+            f"No explicit entry for {name!r} in engine.yaml. If it is provided by "
+            f"a glob, use --dist <distribution> to remove the whole bundle."
+        )
+    return Distribution(value.split(":", 1)[0])
+
+
+def references_distribution(nodes: Mapping[str, NodeEntry], dist: Distribution) -> bool:
+    """Whether any `nodes:` entry still references `dist`."""
+    for key, value in nodes.items():
+        if _is_glob_key(key):
+            if any(Distribution(d) == dist for d in _glob_dists(value)):
+                return True
+        elif isinstance(value, str):
+            if Distribution(value.split(":", 1)[0]) == dist:
+                return True
+    return False
+
+
+def remove_distribution_entries(
+    nodes: Mapping[str, NodeEntry], dist: Distribution
+) -> dict[str, NodeEntry]:
+    """Drop every explicit entry and glob membership referencing `dist`.
+
+    A glob key whose list empties out is dropped entirely.
+    """
+    out: dict[str, NodeEntry] = {}
+    for key, value in nodes.items():
+        if _is_glob_key(key):
+            kept = [d for d in _glob_dists(value) if Distribution(d) != dist]
+            if not kept:
+                continue
+            out[key] = kept if isinstance(value, list) else kept[0]
+        elif isinstance(value, str) and Distribution(value.split(":", 1)[0]) == dist:
+            continue
+        else:
+            out[key] = value
+    return out
+
+
+def remaining_mapped_extras(
+    nodes: Mapping[str, NodeEntry],
+    dist: Distribution,
+    available: Sequence[MountedNode],
+) -> Sequence[str]:
+    """The extras union of `dist`'s nodes that are still mapped by `nodes`.
+
+    A glob membership mounts every node `dist` exposes, so it pins the full
+    extra set; otherwise only the explicitly-mapped entry-point names count.
+    """
+    for key, value in nodes.items():
+        if _is_glob_key(key) and any(
+            Distribution(d) == dist for d in _glob_dists(value)
+        ):
+            return extras_union(available)
+    mapped_names = {
+        value.split(":", 1)[1]
+        for value in nodes.values()
+        if isinstance(value, str)
+        and ":" in value
+        and Distribution(value.split(":", 1)[0]) == dist
+    }
+    return extras_union([m for m in available if m.entry_point_name in mapped_names])
+
+
+def narrow_dependency_extras(
+    root: Path, dist: Distribution, extras: Sequence[str]
+) -> bool:
+    """Rewrite `dist`'s `[project.dependencies]` entry to exactly `extras`.
+
+    Returns whether `pyproject.toml` changed. Edits the dependency string in
+    place (preserving its version specifier / direct-URL and the rest of the
+    file), so `[tool.uv.sources]` is left untouched. A no-op — and so `False` —
+    if `dist` is not a direct dependency or already has exactly `extras`.
+    """
+    path = root / "pyproject.toml"
+    text = path.read_text()
+    for dep in read_pyproject_dependencies(root):
+        req = Requirement(dep)
+        if Distribution(req.name) != dist:
+            continue
+        if req.extras == set(extras):
+            return False
+        req.extras = set(extras)
+        new_dep = str(req)
+        for quote in ('"', "'"):
+            quoted = f"{quote}{dep}{quote}"
+            if quoted in text:
+                path.write_text(text.replace(quoted, f"{quote}{new_dep}{quote}", 1))
+                return True
+        raise UninstallError(
+            f"Could not locate dependency {dep!r} in {path} to re-narrow its extras."
+        )
+    return False
+
+
+# ---------- orchestration ----------
+
+
+def uninstall(
+    name: str | None = None,
+    *,
+    dist: str | None = None,
+    start: Path | None = None,
+) -> UninstallResult:
+    """Remove a node mapping (or a whole distribution) and reconcile `uv`.
+
+    Exactly one of `name` / `dist` must be given. See the module docstring.
+    """
+    if (name is None) == (dist is None):
+        raise UninstallError("Provide either a node name or --dist, but not both.")
+
+    project = UvProject.locate(start or Path.cwd())
+    nodes = load_nodes_block(project.engine_yaml)
+
+    if dist is not None:
+        target = Distribution(dist)
+        if not references_distribution(nodes, target):
+            raise UninstallError(f"No engine.yaml entry references {target.root!r}.")
+        new_nodes = remove_distribution_entries(nodes, target)
+    else:
+        assert name is not None
+        target = distribution_for_node(nodes, name)
+        new_nodes = dict(nodes)
+        del new_nodes[name]
+
+    # Write the name map first (see the module docstring on ordering), then
+    # reconcile pyproject to match what is still mapped.
+    write_nodes_block(project.engine_yaml, new_nodes)
+
+    if references_distribution(new_nodes, target):
+        # Still mapped — re-narrow its extras to the union of what remains.
+        available = read_distribution_entry_points(project.root, target)
+        new_extras = remaining_mapped_extras(new_nodes, target, available)
+        if narrow_dependency_extras(project.root, target, new_extras):
+            _run_uv(project.sync, target)
+        removed = False
+    else:
+        _run_uv(lambda: project.remove(target.root), target)
+        removed = True
+
+    return UninstallResult(distribution=target, removed_distribution=removed)
+
+
+def _run_uv(action: Callable[[], None], dist: Distribution) -> None:
+    """Run a `uv` mutation, surfacing failures as `UninstallError`.
+
+    `engine.yaml` is written only after this returns, so a failure here leaves
+    the name map untouched.
+    """
+    try:
+        action()
+    except subprocess.CalledProcessError as e:
+        raise UninstallError(f"uv failed while reconciling {dist.root!r}: {e}") from e
+
+
+__all__ = ["UninstallError", "UninstallResult", "uninstall"]

--- a/src/workflow_engine/cli/uninstall.py
+++ b/src/workflow_engine/cli/uninstall.py
@@ -68,16 +68,19 @@ def _is_glob_key(key: str) -> bool:
     return key == "*" or key.endswith(":*")
 
 
-def _glob_dists(value: NodeEntry) -> list[str]:
+def _glob_dists(value: NodeEntry) -> Sequence[str]:
     """The distribution list under a glob value (a name or a list of names)."""
     if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [str(v) for v in value]
+        return (value,)
+    if isinstance(value, Sequence):
+        return tuple(str(v) for v in value)
     raise UninstallError(f"Glob entry has an unexpected value: {value!r}.")
 
 
-def distribution_for_node(nodes: Mapping[str, NodeEntry], name: str) -> Distribution:
+def distribution_for_node(
+    nodes: Mapping[str, NodeEntry],
+    name: str,
+) -> Distribution:
     """The distribution an *explicit* `name` entry points at.
 
     Raises `UninstallError` if `name` has no explicit entry (it may be supplied
@@ -92,7 +95,10 @@ def distribution_for_node(nodes: Mapping[str, NodeEntry], name: str) -> Distribu
     return Distribution(value.split(":", 1)[0])
 
 
-def references_distribution(nodes: Mapping[str, NodeEntry], dist: Distribution) -> bool:
+def references_distribution(
+    nodes: Mapping[str, NodeEntry],
+    dist: Distribution,
+) -> bool:
     """Whether any `nodes:` entry still references `dist`."""
     for key, value in nodes.items():
         if _is_glob_key(key):
@@ -105,8 +111,9 @@ def references_distribution(nodes: Mapping[str, NodeEntry], dist: Distribution) 
 
 
 def remove_distribution_entries(
-    nodes: Mapping[str, NodeEntry], dist: Distribution
-) -> dict[str, NodeEntry]:
+    nodes: Mapping[str, NodeEntry],
+    dist: Distribution,
+) -> Mapping[str, NodeEntry]:
     """Drop every explicit entry and glob membership referencing `dist`.
 
     A glob key whose list empties out is dropped entirely.
@@ -151,7 +158,9 @@ def remaining_mapped_extras(
 
 
 def narrow_dependency_extras(
-    root: Path, dist: Distribution, extras: Sequence[str]
+    root: Path,
+    dist: Distribution,
+    extras: Sequence[str],
 ) -> bool:
     """Rewrite `dist`'s `[project.dependencies]` entry to exactly `extras`.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1056,3 +1056,52 @@ class TestVerify:
         wf_dir.mkdir()
         result = invoke_cli(runner, "verify", str(wf_dir))
         assert result.exit_code != 0
+
+
+# ---------- uninstall ----------
+
+
+class TestUninstall:
+    def test_unmaps_node_and_removes_dist(self, runner: CliRunner, monkeypatch):
+        from workflow_engine.cli import install as install_module
+        from workflow_engine.cli import uv_project as uv_project_module
+
+        calls: list[list[str]] = []
+
+        def fake_run_uv(args, **k):
+            calls.append(list(args))
+            if args[0] == "remove":
+                Path("pyproject.toml").write_text(
+                    '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+                )
+
+        monkeypatch.setattr(uv_project_module, "_run_uv", fake_run_uv)
+        monkeypatch.setattr(
+            install_module,
+            "_uv_run_python",
+            lambda root, code, *a: json.dumps([{"name": "Foo", "extras": []}]),
+        )
+
+        with runner.isolated_filesystem():
+            Path("engine.yaml").write_text(
+                "schema_version: 1\nnodes:\n  Foo: acme-pkg:Foo\n"
+            )
+            Path("pyproject.toml").write_text(
+                '[project]\nname = "x"\nversion = "0"\ndependencies = ["acme-pkg"]\n'
+            )
+            result = invoke_cli(runner, "uninstall", "Foo")
+            assert result.exit_code == 0, result.output
+            assert "Uninstalled acme-pkg" in result.output
+            assert ["remove", "acme-pkg"] in calls
+            assert yaml.safe_load(Path("engine.yaml").read_text())["nodes"] == {}
+
+    def test_unknown_node_errors(self, runner: CliRunner, monkeypatch):
+        from workflow_engine.cli import uv_project as uv_project_module
+
+        monkeypatch.setattr(uv_project_module, "_run_uv", lambda *a, **k: None)
+        with runner.isolated_filesystem():
+            Path("engine.yaml").write_text("schema_version: 1\nnodes: {}\n")
+            Path("pyproject.toml").write_text('[project]\nname = "x"\nversion = "0"\n')
+            result = invoke_cli(runner, "uninstall", "Nope")
+            assert result.exit_code != 0
+            assert "No explicit entry" in result.output

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,312 @@
+"""Tests for `wengine uninstall` — pure helpers and the uninstall orchestrator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from workflow_engine.cli import install as install_module
+from workflow_engine.cli import uv_project as uv_project_module
+from workflow_engine.cli.install import (
+    MountedNode,
+    load_nodes_block,
+    read_pyproject_dependencies,
+)
+from workflow_engine.cli.uninstall import (
+    UninstallError,
+    distribution_for_node,
+    narrow_dependency_extras,
+    references_distribution,
+    remaining_mapped_extras,
+    remove_distribution_entries,
+    uninstall,
+)
+from workflow_engine.core.config import Distribution
+
+# ---------- pure helpers ----------
+
+
+class TestDistributionForNode:
+    def test_explicit_entry(self):
+        nodes = {"Sum": "aceteam-workflow-engine:Sum"}
+        assert distribution_for_node(nodes, "Sum") == Distribution(
+            "aceteam-workflow-engine"
+        )
+
+    def test_glob_only_name_errors(self):
+        nodes = {"*": ["acme-scrapers"]}
+        with pytest.raises(UninstallError, match="No explicit entry"):
+            distribution_for_node(nodes, "HttpFetch")
+
+    def test_missing_name_errors(self):
+        with pytest.raises(UninstallError, match="No explicit entry"):
+            distribution_for_node({}, "Nope")
+
+
+class TestReferencesDistribution:
+    def test_explicit(self):
+        assert references_distribution({"Sum": "acme:Sum"}, Distribution("acme"))
+
+    def test_glob_list(self):
+        assert references_distribution({"*": ["acme", "other"]}, Distribution("acme"))
+
+    def test_prefixed_glob_string(self):
+        assert references_distribution({"v/legacy:*": "acme"}, Distribution("acme"))
+
+    def test_canonical_name_match(self):
+        # PEP 503: "Acme_Scrapers" and "acme-scrapers" are the same distribution.
+        assert references_distribution(
+            {"Foo": "Acme_Scrapers:Foo"}, Distribution("acme-scrapers")
+        )
+
+    def test_absent(self):
+        assert not references_distribution({"Sum": "other:Sum"}, Distribution("acme"))
+
+
+class TestRemoveDistributionEntries:
+    def test_drops_explicit_and_glob_membership(self):
+        nodes = {
+            "Sum": "aceteam-workflow-engine:Sum",
+            "Foo": "acme:Foo",
+            "*": ["acme", "other"],
+        }
+        out = remove_distribution_entries(nodes, Distribution("acme"))
+        assert out == {"Sum": "aceteam-workflow-engine:Sum", "*": ["other"]}
+
+    def test_drops_emptied_glob_key(self):
+        out = remove_distribution_entries({"*": ["acme"]}, Distribution("acme"))
+        assert out == {}
+
+    def test_drops_single_string_glob(self):
+        out = remove_distribution_entries(
+            {"v/legacy:*": "acme", "Sum": "x:Sum"}, Distribution("acme")
+        )
+        assert out == {"Sum": "x:Sum"}
+
+
+class TestRemainingMappedExtras:
+    def test_explicit_entries_only(self):
+        nodes = {"Cap": "acme:Screenshot"}
+        available = [
+            MountedNode(entry_point_name="Screenshot", extras=("screenshot",)),
+            MountedNode(entry_point_name="HttpFetch", extras=()),
+        ]
+        assert remaining_mapped_extras(nodes, Distribution("acme"), available) == (
+            "screenshot",
+        )
+
+    def test_glob_pins_full_extra_set(self):
+        # A glob mounts every node, so the union spans all of them.
+        nodes = {"*": ["acme"]}
+        available = [
+            MountedNode(entry_point_name="Screenshot", extras=("screenshot",)),
+            MountedNode(entry_point_name="Crawl", extras=("browser",)),
+        ]
+        assert remaining_mapped_extras(nodes, Distribution("acme"), available) == (
+            "browser",
+            "screenshot",
+        )
+
+
+class TestNarrowDependencyExtras:
+    def test_shrinks_extras_preserving_version(self, tmp_path: Path):
+        _write_deps(tmp_path / "pyproject.toml", ["acme[a,b]>=1.0"])
+        assert narrow_dependency_extras(tmp_path, Distribution("acme"), ["a"]) is True
+        assert read_pyproject_dependencies(tmp_path) == ["acme[a]>=1.0"]
+
+    def test_drops_all_extras(self, tmp_path: Path):
+        _write_deps(tmp_path / "pyproject.toml", ["acme[a,b]"])
+        assert narrow_dependency_extras(tmp_path, Distribution("acme"), []) is True
+        assert read_pyproject_dependencies(tmp_path) == ["acme"]
+
+    def test_no_change_when_already_exact(self, tmp_path: Path):
+        _write_deps(tmp_path / "pyproject.toml", ["acme[a]"])
+        assert narrow_dependency_extras(tmp_path, Distribution("acme"), ["a"]) is False
+
+    def test_no_change_when_not_a_direct_dependency(self, tmp_path: Path):
+        _write_deps(tmp_path / "pyproject.toml", ["other"])
+        assert narrow_dependency_extras(tmp_path, Distribution("acme"), []) is False
+
+    def test_leaves_uv_sources_untouched(self, tmp_path: Path):
+        # The dependency line carries the extras; the source mapping is separate.
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "h"\nversion = "0"\n'
+            'dependencies = ["acme[a,b]"]\n\n'
+            "[tool.uv.sources]\n"
+            'acme = { git = "https://example.com/acme", rev = "v1" }\n'
+        )
+        assert narrow_dependency_extras(tmp_path, Distribution("acme"), ["a"]) is True
+        text = pyproject.read_text()
+        assert '"acme[a]"' in text
+        assert 'git = "https://example.com/acme"' in text
+
+
+# ---------- orchestrator (with a uv-simulating fake) ----------
+
+
+def _write_deps(pyproject: Path, deps: list[str]) -> None:
+    body = "".join(f'    "{d}",\n' for d in deps)
+    pyproject.write_text(
+        f'[project]\nname = "host"\nversion = "0"\ndependencies = [\n{body}]\n'
+    )
+
+
+def _write_engine(project: Path, nodes_yaml: str) -> None:
+    (project / "engine.yaml").write_text(f"schema_version: 1\nnodes:\n{nodes_yaml}")
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """An embedded engine project (engine.yaml + pyproject side by side)."""
+    _write_deps(tmp_path / "pyproject.toml", ["aceteam-workflow-engine"])
+    return tmp_path
+
+
+def _patch_uv(
+    monkeypatch,
+    project: Path,
+    entry_points: dict[str, list[MountedNode]],
+) -> list[list[str]]:
+    """Simulate `uv add`/`uv remove` mutating pyproject, and entry-point reads."""
+    pyproject = project / "pyproject.toml"
+    calls: list[list[str]] = []
+
+    def fake_run_uv(args: list[str], *, cwd):
+        calls.append(list(args))
+        deps = read_pyproject_dependencies(project)
+        if args[0] == "add":
+            req = args[-1]
+            name = Distribution.from_requirement(req)
+            deps = [d for d in deps if Distribution.from_requirement(d) != name]
+            deps.append(req)
+            _write_deps(pyproject, deps)
+        elif args[0] == "remove":
+            name = Distribution(args[-1])
+            deps = [d for d in deps if Distribution.from_requirement(d) != name]
+            _write_deps(pyproject, deps)
+        # "sync" reconciles the lockfile from pyproject — a no-op for the fake.
+
+    def fake_uv_run_python(root: Path, code: str, *args: str):
+        target = Distribution(args[-1])
+        mounts = next(
+            (m for k, m in entry_points.items() if Distribution(k) == target), []
+        )
+        return json.dumps(
+            [{"name": m.entry_point_name, "extras": list(m.extras)} for m in mounts]
+        )
+
+    monkeypatch.setattr(uv_project_module, "_run_uv", fake_run_uv)
+    monkeypatch.setattr(install_module, "_uv_run_python", fake_uv_run_python)
+    return calls
+
+
+class TestUninstallOrchestrator:
+    def test_name_last_entry_uv_removes(self, project: Path, monkeypatch):
+        # Sum is the only entry for acme — uninstalling it removes the package.
+        _write_engine(project, "  Sum: acme:Sum\n")
+        _write_deps(project / "pyproject.toml", ["aceteam-workflow-engine", "acme"])
+        calls = _patch_uv(
+            monkeypatch,
+            project,
+            {"acme": [MountedNode(entry_point_name="Sum", extras=())]},
+        )
+
+        result = uninstall("Sum", start=project)
+
+        assert result.removed_distribution is True
+        assert result.distribution == Distribution("acme")
+        assert ["remove", "acme"] in calls
+        assert load_nodes_block(project / "engine.yaml") == {}
+
+    def test_name_still_referenced_renarrows_extras(self, project: Path, monkeypatch):
+        # acme exposes Screenshot[screenshot] and HttpFetch[]; both are mapped and
+        # pyproject pins [screenshot]. Dropping Screenshot leaves only HttpFetch,
+        # which needs no extra, so the dependency is narrowed to bare acme and the
+        # lockfile reconciled with `uv sync` (the package stays installed).
+        _write_engine(project, "  Cap: acme:Screenshot\n  Fetch: acme:HttpFetch\n")
+        _write_deps(
+            project / "pyproject.toml", ["aceteam-workflow-engine", "acme[screenshot]"]
+        )
+        eps = {
+            "acme": [
+                MountedNode(entry_point_name="Screenshot", extras=("screenshot",)),
+                MountedNode(entry_point_name="HttpFetch", extras=()),
+            ]
+        }
+        calls = _patch_uv(monkeypatch, project, eps)
+
+        result = uninstall("Cap", start=project)
+
+        assert result.removed_distribution is False
+        assert ["sync"] in calls
+        assert all(c[0] != "remove" for c in calls)
+        assert "acme" in read_pyproject_dependencies(project)  # narrowed, not removed
+        assert read_pyproject_dependencies(project) == [
+            "aceteam-workflow-engine",
+            "acme",
+        ]
+        nodes = load_nodes_block(project / "engine.yaml")
+        assert "Cap" not in nodes
+        assert nodes["Fetch"] == "acme:HttpFetch"
+
+    def test_name_still_referenced_no_extra_change_skips_uv(
+        self, project: Path, monkeypatch
+    ):
+        # Removing one explicit entry while acme stays on the "*" glob keeps every
+        # node mapped, so the extra set is unchanged — no uv call should fire.
+        _write_engine(project, '  Cap: acme:Screenshot\n  "*":\n    - acme\n')
+        _write_deps(
+            project / "pyproject.toml", ["aceteam-workflow-engine", "acme[screenshot]"]
+        )
+        eps = {
+            "acme": [MountedNode(entry_point_name="Screenshot", extras=("screenshot",))]
+        }
+        calls = _patch_uv(monkeypatch, project, eps)
+
+        result = uninstall("Cap", start=project)
+
+        assert result.removed_distribution is False
+        assert calls == []  # extras already match (glob pins the full set)
+        nodes = load_nodes_block(project / "engine.yaml")
+        assert "Cap" not in nodes
+        assert nodes["*"] == ["acme"]
+
+    def test_dist_removes_all_entries(self, project: Path, monkeypatch):
+        _write_engine(
+            project,
+            '  Sum: aceteam-workflow-engine:Sum\n  Cap: acme:Screenshot\n  "*":\n    - acme\n    - other\n',
+        )
+        _write_deps(project / "pyproject.toml", ["aceteam-workflow-engine", "acme"])
+        calls = _patch_uv(
+            monkeypatch,
+            project,
+            {"acme": [MountedNode(entry_point_name="Screenshot", extras=())]},
+        )
+
+        result = uninstall(dist="acme", start=project)
+
+        assert result.removed_distribution is True
+        assert ["remove", "acme"] in calls
+        nodes = load_nodes_block(project / "engine.yaml")
+        assert nodes == {"Sum": "aceteam-workflow-engine:Sum", "*": ["other"]}
+
+    def test_dist_not_referenced_errors(self, project: Path, monkeypatch):
+        _write_engine(project, "  Sum: aceteam-workflow-engine:Sum\n")
+        _patch_uv(monkeypatch, project, {})
+        with pytest.raises(UninstallError, match=r"No engine\.yaml entry references"):
+            uninstall(dist="acme", start=project)
+
+    def test_name_and_dist_both_given_errors(self, project: Path, monkeypatch):
+        _write_engine(project, "  Sum: acme:Sum\n")
+        _patch_uv(monkeypatch, project, {})
+        with pytest.raises(UninstallError, match="either a node name or --dist"):
+            uninstall("Sum", dist="acme", start=project)
+
+    def test_neither_given_errors(self, project: Path, monkeypatch):
+        _write_engine(project, "  Sum: acme:Sum\n")
+        _patch_uv(monkeypatch, project, {})
+        with pytest.raises(UninstallError, match="either a node name or --dist"):
+            uninstall(start=project)


### PR DESCRIPTION
## Summary

Adds `wengine uninstall <name>` / `wengine uninstall --dist <name>`, the inverse of `wengine install` — closing build-order step 5 of docs/plans/node-distribution.md (`init` / `install` / `uninstall`).

**Stacked on #144** (which is stacked on #143) — review/merge those first.

## Behavior

- **By node name**: drops that name's explicit entry from `engine.yaml`. If other entries still reference the distribution, it stays installed and its extras are re-narrowed to the union of the still-mapped nodes; otherwise `uv remove`.
- **By distribution** (`--dist`): removes every entry referencing it (explicit entries plus `"*"` / `"prefix:*"` glob membership), then uninstalls it.

## Extras reconcile — the uv subtlety

The plan originally said to re-narrow extras with `uv add <dist>[<new set>]`. **That doesn't work**: `uv add` only *merges* extras (there's no reset flag), so it can't shrink, and `uv remove`+re-add wipes the dist's `[tool.uv.sources]` entry (silently repointing git/path installs to PyPI). Verified against uv 0.9.24.

Instead, uninstall rewrites the extras on the dependency's `[project.dependencies]` line and runs `uv sync`. This preserves `[tool.uv.sources]`, drops now-unneeded transitive deps, and behaves identically for git/path/workspace/PyPI sources. The plan's "Uninstalling" section is corrected to match.

`engine.yaml` is written **before** `pyproject.toml` is reconciled, so a failed `uv` step leaves only superfluous extras behind — never an unmapped-but-still-needed node or a removed-but-still-referenced distribution.

## Tests

`tests/test_uninstall.py` — pure helpers (`distribution_for_node`, `references_distribution`, `remove_distribution_entries`, `remaining_mapped_extras`, `narrow_dependency_extras`) plus the orchestrator on the same uv-faking harness `test_install.py` uses. A `TestUninstall` class in `test_cli.py` covers the command end-to-end. Full suite green (640 passed), ruff + pyright clean.

## Docs

`docs/cli.md` gains a "Managing the engine project" section documenting `init` / `install` / `uninstall`; the plan's Uninstalling section is corrected to the pyproject-edit + `uv sync` mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)