### PR TITLE
refactor: rename write_nodes_block -> replace_nodes_block

### DIFF
--- a/src/workflow_engine/cli/install.py
+++ b/src/workflow_engine/cli/install.py
@@ -196,8 +196,14 @@ def load_nodes_block(engine_yaml: Path) -> dict[str, NodeEntry]:
     }
 
 
-def write_nodes_block(engine_yaml: Path, nodes: Mapping[str, NodeEntry]) -> None:
-    """Write `nodes` back into `engine.yaml`, preserving the rest of the document.
+def replace_nodes_block(engine_yaml: Path, nodes: Mapping[str, NodeEntry]) -> None:
+    """Replace the entire `nodes:` block of `engine.yaml` with `nodes`.
+
+    `nodes` must be the *complete* desired block: any existing `nodes:` entry
+    not present in `nodes` is dropped. The intended use is to load the current
+    block with `load_nodes_block`, mutate it, and pass the whole thing back —
+    passing a partial mapping silently deletes the omitted entries. Other
+    top-level keys of the document are untouched either way.
 
     The new block is validated through `NodesConfig` first. The write edits the
     round-trip document in place — surviving keys keep their comments and
@@ -407,7 +413,7 @@ def install(
     explicit_names = plan_explicit_names(only, as_name) if only else {}
     # The recognized names (notably a free-form `--as`) are known before any
     # `uv` call, so validate their grammar now — otherwise an invalid name only
-    # trips `write_nodes_block` after the package is already installed.
+    # trips `replace_nodes_block` after the package is already installed.
     check_recognized_name_grammar(tuple(explicit_names))
     if explicit_names and isinstance(parsed, PyPITarget):
         pre_dist = Distribution.from_requirement(parsed.requirement)
@@ -461,7 +467,7 @@ def install(
             f"rolled back."
         ) from e
 
-    write_nodes_block(project.engine_yaml, new_nodes)
+    replace_nodes_block(project.engine_yaml, new_nodes)
     return dist
 
 

--- a/src/workflow_engine/cli/uninstall.py
+++ b/src/workflow_engine/cli/uninstall.py
@@ -44,7 +44,7 @@ from .install import (
     load_nodes_block,
     read_distribution_entry_points,
     read_pyproject_dependencies,
-    write_nodes_block,
+    replace_nodes_block,
 )
 from .uv_project import UvProject
 
@@ -222,7 +222,7 @@ def uninstall(
 
     # Write the name map first (see the module docstring on ordering), then
     # reconcile pyproject to match what is still mapped.
-    write_nodes_block(project.engine_yaml, new_nodes)
+    replace_nodes_block(project.engine_yaml, new_nodes)
 
     if references_distribution(new_nodes, target):
         # Still mapped — re-narrow its extras to the union of what remains.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -24,9 +24,9 @@ from workflow_engine.cli.install import (
     merge_glob,
     plan_explicit_names,
     read_pyproject_dependencies,
+    replace_nodes_block,
     resolve_only_mounts,
     with_extras,
-    write_nodes_block,
 )
 from workflow_engine.core.config import Distribution
 
@@ -181,10 +181,25 @@ class TestNodesBlockIO:
         )
         nodes = load_nodes_block(engine_yaml)
         nodes["New"] = "acme:New"
-        write_nodes_block(engine_yaml, nodes)
+        replace_nodes_block(engine_yaml, nodes)
         reloaded = yaml.safe_load(engine_yaml.read_text())
         assert reloaded["schema_version"] == 1
         assert reloaded["nodes"]["New"] == "acme:New"
+
+    def test_replaces_block_dropping_omitted_entries(self, tmp_path: Path):
+        # replace_nodes_block writes the *complete* block: a partial mapping
+        # drops the entries it omits. Callers must load → mutate → write back.
+        engine_yaml = tmp_path / "engine.yaml"
+        engine_yaml.write_text(
+            "schema_version: 1\n"
+            "nodes:\n"
+            "  Sum: aceteam-workflow-engine:Sum\n"
+            "  Product: aceteam-workflow-engine:Product\n"
+        )
+        replace_nodes_block(engine_yaml, {"Sum": "aceteam-workflow-engine:Sum"})
+        reloaded = yaml.safe_load(engine_yaml.read_text())
+        assert "Product" not in reloaded["nodes"]  # omitted → dropped
+        assert reloaded["nodes"]["Sum"] == "aceteam-workflow-engine:Sum"
 
     def test_preserves_comments_and_unknown_keys(self, tmp_path: Path):
         engine_yaml = tmp_path / "engine.yaml"
@@ -198,7 +213,7 @@ class TestNodesBlockIO:
         )
         nodes = load_nodes_block(engine_yaml)
         nodes["New"] = "acme:New"
-        write_nodes_block(engine_yaml, nodes)
+        replace_nodes_block(engine_yaml, nodes)
         text = engine_yaml.read_text()
         assert "# top comment" in text
         assert "# inline" in text  # comment on a surviving entry is kept


### PR DESCRIPTION
## What

`write_nodes_block` (in `cli/install.py`) fully **replaces** the `nodes:` block of `engine.yaml` — any existing entry not present in the passed mapping is dropped — but its name and docstring read like a targeted "write back". That makes its safety silently dependent on the caller having loaded the complete prior block first (`load_nodes_block` → mutate → write). Same shape as the `uv remove` footgun: hand it a partial and it clobbers the rest.

Both current callers (`install`, `uninstall`) already do the load-mutate-write dance correctly, so **no behavior change** — this is a clarity fix to stop the next caller from passing a partial mapping and silently deleting entries.

## Changes

- Rename `write_nodes_block` → `replace_nodes_block`.
- Rewrite the docstring to state `nodes` must be the *complete* desired block, and that omitted entries are dropped (other top-level keys are still untouched).
- Update both call sites and the test imports.
- Add `test_replaces_block_dropping_omitted_entries` pinning the replace semantics so the contract is enforced, not just documented.

## Notes

- Pure rename + docstring + test. `ruff`, `pyright` (0 errors), full suite (644 passed, 1 pre-existing xfail) all green.
- The intentional auto-drop of type-incompatible edges in `workflow edit update-node`/`update-field` is left as-is by design (fast path that alerts) — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)