### PR TITLE
feat: add comparison and logic nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project uses [PEP 440](https://peps.python.org/pep-0440/) versioning with release candidates (rcN) for pre-release versions.
 
+## [Unreleased]
+
+### Added
+- **Comparison and logic nodes** — built-in boolean nodes for branching and gating workflows:
+  - Comparison: `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual` (two `FloatValue` inputs → `BooleanValue`).
+  - Logic: `And` and `Or` are variadic (a `num_arguments` parameter controls how many boolean inputs appear, like `Add`), plus a unary `Not`.
+  - `Equal` / `NotEqual` compare with `math.isclose` and accept optional `rel_tol` (default `1e-9`) and `abs_tol` (default `0.0`) parameters to absorb floating-point rounding; set both to `0` for an exact comparison.
+
 ## [2.0.0rc12] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project uses [PEP 440](https://peps.python.org/pep-0440/) versioning with r
 - **Comparison and logic nodes** — built-in boolean nodes for branching and gating workflows:
   - Comparison: `Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual` (two `FloatValue` inputs → `BooleanValue`).
   - Logic: `And` and `Or` are variadic (a `num_arguments` parameter controls how many boolean inputs appear, like `Add`), plus a unary `Not`.
-  - `Equal` / `NotEqual` compare with `math.isclose` and accept optional `rel_tol` (default `1e-9`) and `abs_tol` (default `0.0`) parameters to absorb floating-point rounding; set both to `0` for an exact comparison.
+  - `Equal` / `NotEqual` compare with `math.isclose`. They are exact by default (`rel_tol` and `abs_tol` both default to `0`) and accept optional `rel_tol` / `abs_tol` parameters to absorb floating-point rounding when needed.
 
 ## [2.0.0rc12] - 2026-05-29
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -53,7 +53,7 @@ Each comparison node takes two `FloatValue` inputs `a` and `b` and outputs a `Bo
 { "type": "GreaterThan", "id": "gt1", "params": {} }
 ```
 
-`Equal` and `NotEqual` compare with `math.isclose`, so they accept optional `rel_tol` (relative tolerance, default `1e-9`) and `abs_tol` (absolute tolerance, default `0.0`) parameters to absorb floating-point rounding. Set both to `0` for an exact comparison; use `abs_tol` when comparing values near zero.
+`Equal` and `NotEqual` compare with `math.isclose`. By default both tolerances are `0`, so the comparison is **exact**. To absorb floating-point rounding, set `rel_tol` (relative tolerance) and/or `abs_tol` (absolute tolerance); use `abs_tol` when comparing values near zero, where a relative tolerance is too strict.
 
 ```json
 { "type": "Equal", "id": "eq1", "params": { "rel_tol": 1e-6, "abs_tol": 1e-9 } }

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -36,6 +36,64 @@ Factorizes an integer into its prime factors.
 | **Input** `value`    | `IntegerValue`                |
 | **Output** `factors` | `SequenceValue[IntegerValue]` |
 
+## Comparison
+
+Each comparison node takes two `FloatValue` inputs `a` and `b` and outputs a `BooleanValue` `result`. `IntegerValue` sources cast to `FloatValue` automatically.
+
+| Node               | `result` is true when |
+| ------------------ | --------------------- |
+| `Equal`            | `a == b`              |
+| `NotEqual`         | `a != b`              |
+| `GreaterThan`      | `a > b`               |
+| `GreaterThanEqual` | `a >= b`              |
+| `LessThan`         | `a < b`               |
+| `LessThanEqual`    | `a <= b`              |
+
+```json
+{ "type": "GreaterThan", "id": "gt1", "params": {} }
+```
+
+`Equal` and `NotEqual` compare with `math.isclose`, so they accept optional `rel_tol` (relative tolerance, default `1e-9`) and `abs_tol` (absolute tolerance, default `0.0`) parameters to absorb floating-point rounding. Set both to `0` for an exact comparison; use `abs_tol` when comparing values near zero.
+
+```json
+{ "type": "Equal", "id": "eq1", "params": { "rel_tol": 1e-6, "abs_tol": 1e-9 } }
+```
+
+## Logic
+
+### And
+
+Outputs true only when all inputs are true. Variadic like `Add`: the `num_arguments` parameter (default `2`, minimum `2`) controls how many boolean inputs (`a`, `b`, `c`, …) appear.
+
+| Field                         | Type           |
+| ----------------------------- | -------------- |
+| **Parameter** `num_arguments` | `IntegerValue` |
+| **Input** `a`, `b`, …         | `BooleanValue` |
+| **Output** `result`           | `BooleanValue` |
+
+```json
+{ "type": "And", "id": "and1", "params": { "num_arguments": 3 } }
+```
+
+### Or
+
+Outputs true when at least one input is true. Variadic like `And` via `num_arguments`.
+
+| Field                         | Type           |
+| ----------------------------- | -------------- |
+| **Parameter** `num_arguments` | `IntegerValue` |
+| **Input** `a`, `b`, …         | `BooleanValue` |
+| **Output** `result`           | `BooleanValue` |
+
+### Not
+
+Returns the opposite of the input value.
+
+| Field               | Type           |
+| ------------------- | -------------- |
+| **Input** `a`       | `BooleanValue` |
+| **Output** `result` | `BooleanValue` |
+
 ## Constants
 
 ### ConstantBoolean

--- a/src/workflow_engine/nodes/__init__.py
+++ b/src/workflow_engine/nodes/__init__.py
@@ -4,6 +4,17 @@ from .arithmetic import (
     FactorizationNode,
     SumNode,
 )
+from .comparison import (
+    AndNode,
+    EqualNode,
+    GreaterThanEqualNode,
+    GreaterThanNode,
+    LessThanEqualNode,
+    LessThanNode,
+    NotEqualNode,
+    NotNode,
+    OrNode,
+)
 from .conditional import (
     ConditionalInput,
     IfElseNode,
@@ -34,11 +45,13 @@ from .text import (
 
 __all__ = [
     "AddNode",
+    "AndNode",
     "AppendToFileNode",
     "ConditionalInput",
     "ConstantBooleanNode",
     "ConstantIntegerNode",
     "ConstantStringNode",
+    "EqualNode",
     "ErrorNode",
     "ExpandDataNode",
     "ExpandMappingNode",
@@ -48,7 +61,14 @@ __all__ = [
     "GatherDataNode",
     "GatherMappingNode",
     "GatherSequenceNode",
+    "GreaterThanEqualNode",
+    "GreaterThanNode",
     "IfElseNode",
     "IfNode",
+    "LessThanEqualNode",
+    "LessThanNode",
+    "NotEqualNode",
+    "NotNode",
+    "OrNode",
     "SumNode",
 ]

--- a/src/workflow_engine/nodes/comparison.py
+++ b/src/workflow_engine/nodes/comparison.py
@@ -47,9 +47,10 @@ class EqualityParams(Params):
         description=(
             "The maximum difference between the two values relative to the larger "
             "of their magnitudes, for them to count as equal. Use this to absorb "
-            "floating-point rounding error."
+            "floating-point rounding error. Defaults to 0, meaning an exact "
+            "comparison."
         ),
-        default=FloatValue(1e-9),
+        default=FloatValue(0.0),
         json_schema_extra={"minimum": 0},
     )
     abs_tol: FloatValue = Field(

--- a/src/workflow_engine/nodes/comparison.py
+++ b/src/workflow_engine/nodes/comparison.py
@@ -1,0 +1,428 @@
+# workflow_engine/nodes/comparison.py
+"""Comparison and logical operator nodes."""
+
+import math
+from typing import ClassVar, Type
+
+from overrides import override
+from pydantic import Field
+
+from ..core import (
+    BooleanValue,
+    Data,
+    Empty,
+    ExecutionContext,
+    FloatValue,
+    IntegerValue,
+    Node,
+    NodeTypeInfo,
+    Params,
+    ValidationContext,
+)
+from ..core.values import build_data_type
+
+
+def _argument_field_name(index: int) -> str:
+    """
+    Generate a field name for the given zero-based index.
+    Produces "a", "b", ..., "z", "aa", "ab", ..., "az", "ba", ...
+    """
+    letters = []
+    n = index
+    while True:
+        letters.append(chr(ord("a") + n % 26))
+        n = n // 26 - 1
+        if n < 0:
+            break
+    return "".join(reversed(letters))
+
+
+class ComparisonParams(Params):
+    pass
+
+
+class EqualityParams(Params):
+    rel_tol: FloatValue = Field(
+        title="Relative Tolerance",
+        description=(
+            "The maximum difference between the two values relative to the larger "
+            "of their magnitudes, for them to count as equal. Use this to absorb "
+            "floating-point rounding error."
+        ),
+        default=FloatValue(1e-9),
+        json_schema_extra={"minimum": 0},
+    )
+    abs_tol: FloatValue = Field(
+        title="Absolute Tolerance",
+        description=(
+            "The maximum absolute difference between the two values for them to "
+            "count as equal. Useful when comparing values near zero, where the "
+            "relative tolerance is too strict."
+        ),
+        default=FloatValue(0.0),
+        json_schema_extra={"minimum": 0},
+    )
+
+
+class LogicalParams(Params):
+    num_arguments: IntegerValue = Field(
+        title="Number of Arguments",
+        description="The number of boolean inputs to combine.",
+        default=IntegerValue(2),
+        json_schema_extra={"minimum": 2},
+    )
+
+
+class ComparisonInput(Data):
+    a: FloatValue = Field(
+        title="A",
+        description="The left value in the comparison.",
+    )
+    b: FloatValue = Field(
+        title="B",
+        description="The right value in the comparison.",
+    )
+
+
+class ComparisonOutput(Data):
+    result: BooleanValue = Field(
+        title="Result",
+        description="The result of the comparison.",
+    )
+
+
+class NotInput(Data):
+    a: BooleanValue = Field(
+        title="A",
+        description="The boolean input to negate.",
+    )
+
+
+class LogicalOutput(Data):
+    result: BooleanValue = Field(
+        title="Result",
+        description="The result of the logical operation.",
+    )
+
+
+# --- Comparison Nodes ---
+
+
+class EqualNode(Node[ComparisonInput, ComparisonOutput, EqualityParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Equal",
+        description=(
+            "Outputs true if the two input values are equal, within the "
+            "configured relative and absolute tolerances."
+        ),
+        version="1.0.0",
+        parameter_type=EqualityParams,
+    )
+
+    # we can do this because an empty EqualityParams is valid
+    params: EqualityParams = Field(default=EqualityParams())  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[ComparisonInput]:
+        return ComparisonInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[ComparisonOutput]:
+        return ComparisonOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[ComparisonInput],
+        output_type: Type[ComparisonOutput],
+        input: ComparisonInput,
+    ) -> ComparisonOutput:
+        result = math.isclose(
+            input.a.root,
+            input.b.root,
+            rel_tol=self.params.rel_tol.root,
+            abs_tol=self.params.abs_tol.root,
+        )
+        return output_type(result=BooleanValue(result))
+
+
+class NotEqualNode(Node[ComparisonInput, ComparisonOutput, EqualityParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Not Equal",
+        description=(
+            "Outputs true if the two input values are not equal, within the "
+            "configured relative and absolute tolerances."
+        ),
+        version="1.0.0",
+        parameter_type=EqualityParams,
+    )
+
+    # we can do this because an empty EqualityParams is valid
+    params: EqualityParams = Field(default=EqualityParams())  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[ComparisonInput]:
+        return ComparisonInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[ComparisonOutput]:
+        return ComparisonOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[ComparisonInput],
+        output_type: Type[ComparisonOutput],
+        input: ComparisonInput,
+    ) -> ComparisonOutput:
+        result = math.isclose(
+            input.a.root,
+            input.b.root,
+            rel_tol=self.params.rel_tol.root,
+            abs_tol=self.params.abs_tol.root,
+        )
+        return output_type(result=BooleanValue(not result))
+
+
+class GreaterThanNode(Node[ComparisonInput, ComparisonOutput, ComparisonParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Greater Than",
+        description="Outputs true if the first value is greater than the second.",
+        version="1.0.0",
+        parameter_type=ComparisonParams,
+    )
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[ComparisonInput]:
+        return ComparisonInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[ComparisonOutput]:
+        return ComparisonOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[ComparisonInput],
+        output_type: Type[ComparisonOutput],
+        input: ComparisonInput,
+    ) -> ComparisonOutput:
+        return output_type(result=BooleanValue(input.a.root > input.b.root))
+
+
+class GreaterThanEqualNode(Node[ComparisonInput, ComparisonOutput, ComparisonParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Greater Than or Equal",
+        description="Outputs true if the first value is greater than or equal to the second.",
+        version="1.0.0",
+        parameter_type=ComparisonParams,
+    )
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[ComparisonInput]:
+        return ComparisonInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[ComparisonOutput]:
+        return ComparisonOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[ComparisonInput],
+        output_type: Type[ComparisonOutput],
+        input: ComparisonInput,
+    ) -> ComparisonOutput:
+        return output_type(result=BooleanValue(input.a.root >= input.b.root))
+
+
+class LessThanNode(Node[ComparisonInput, ComparisonOutput, ComparisonParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Less Than",
+        description="Outputs true if the first value is less than the second.",
+        version="1.0.0",
+        parameter_type=ComparisonParams,
+    )
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[ComparisonInput]:
+        return ComparisonInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[ComparisonOutput]:
+        return ComparisonOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[ComparisonInput],
+        output_type: Type[ComparisonOutput],
+        input: ComparisonInput,
+    ) -> ComparisonOutput:
+        return output_type(result=BooleanValue(input.a.root < input.b.root))
+
+
+class LessThanEqualNode(Node[ComparisonInput, ComparisonOutput, ComparisonParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Less Than or Equal",
+        description="Outputs true if the first value is less than or equal to the second.",
+        version="1.0.0",
+        parameter_type=ComparisonParams,
+    )
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[ComparisonInput]:
+        return ComparisonInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[ComparisonOutput]:
+        return ComparisonOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[ComparisonInput],
+        output_type: Type[ComparisonOutput],
+        input: ComparisonInput,
+    ) -> ComparisonOutput:
+        return output_type(result=BooleanValue(input.a.root <= input.b.root))
+
+
+# --- Logical Nodes ---
+
+
+def _logical_input_type(n: int, name: str) -> Type[Data]:
+    fields = {
+        _argument_field_name(i): (
+            BooleanValue,
+            Field(title=_argument_field_name(i).upper()),
+        )
+        for i in range(n)
+    }
+    return build_data_type(name=name, fields=fields, base_cls=Data)
+
+
+class AndNode(Node[Data, LogicalOutput, LogicalParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Logical AND",
+        description="Outputs true only when all inputs are true.",
+        version="1.0.0",
+        parameter_type=LogicalParams,
+    )
+
+    # we can do this because an empty LogicalParams is valid
+    params: LogicalParams = Field(default=LogicalParams())  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    @override
+    async def dynamic_input_type(self, context: ValidationContext) -> Type[Data]:
+        return _logical_input_type(self.params.num_arguments.root, "AndNodeInput")
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[LogicalOutput]:
+        return LogicalOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[Data],
+        output_type: Type[LogicalOutput],
+        input: Data,
+    ) -> LogicalOutput:
+        result = all(
+            getattr(input, _argument_field_name(i)).root
+            for i in range(self.params.num_arguments.root)
+        )
+        return output_type(result=BooleanValue(result))
+
+
+class OrNode(Node[Data, LogicalOutput, LogicalParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Logical OR",
+        description="Outputs true when at least one input is true.",
+        version="1.0.0",
+        parameter_type=LogicalParams,
+    )
+
+    # we can do this because an empty LogicalParams is valid
+    params: LogicalParams = Field(default=LogicalParams())  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    @override
+    async def dynamic_input_type(self, context: ValidationContext) -> Type[Data]:
+        return _logical_input_type(self.params.num_arguments.root, "OrNodeInput")
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[LogicalOutput]:
+        return LogicalOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[Data],
+        output_type: Type[LogicalOutput],
+        input: Data,
+    ) -> LogicalOutput:
+        result = any(
+            getattr(input, _argument_field_name(i)).root
+            for i in range(self.params.num_arguments.root)
+        )
+        return output_type(result=BooleanValue(result))
+
+
+class NotNode(Node[NotInput, LogicalOutput, Empty]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Logical NOT",
+        description="Returns the opposite of the input value.",
+        version="1.0.0",
+        parameter_type=Empty,
+    )
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[NotInput]:
+        return NotInput
+
+    @classmethod
+    @override
+    def static_output_type(cls) -> Type[LogicalOutput]:
+        return LogicalOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[NotInput],
+        output_type: Type[LogicalOutput],
+        input: NotInput,
+    ) -> LogicalOutput:
+        return output_type(result=BooleanValue(not input.a.root))

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,202 @@
+import pytest
+
+from workflow_engine import (
+    BooleanValue,
+    Edge,
+    FloatValue,
+    Workflow,
+    WorkflowEngine,
+    WorkflowExecutionResultStatus,
+)
+from workflow_engine.contexts import InMemoryExecutionContext
+from workflow_engine.nodes import (
+    AndNode,
+    EqualNode,
+    GreaterThanEqualNode,
+    GreaterThanNode,
+    LessThanEqualNode,
+    LessThanNode,
+    NotEqualNode,
+    NotNode,
+    OrNode,
+)
+
+
+@pytest.fixture
+def engine() -> WorkflowEngine:
+    return WorkflowEngine()
+
+
+async def _run_comparison(
+    engine: WorkflowEngine,
+    node_cls: type,
+    a: float,
+    b: float,
+    params: dict | None = None,
+) -> bool:
+    workflow = Workflow(
+        input_node=(input_node := engine.create_input_node(a=FloatValue, b=FloatValue)),
+        output_node=(output_node := engine.create_output_node(result=BooleanValue)),
+        inner_nodes=[
+            cmp := engine.create_node(node_cls, id="cmp", params=params or {})
+        ],
+        edges=[
+            Edge.from_nodes(
+                source=input_node, source_key="a", target=cmp, target_key="a"
+            ),
+            Edge.from_nodes(
+                source=input_node, source_key="b", target=cmp, target_key="b"
+            ),
+            Edge.from_nodes(
+                source=cmp,
+                source_key="result",
+                target=output_node,
+                target_key="result",
+            ),
+        ],
+    )
+    result = await engine.execute(
+        context=InMemoryExecutionContext(),
+        workflow=workflow,
+        input={"a": FloatValue(a), "b": FloatValue(b)},
+    )
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    return result.output["result"].root
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "node_cls, a, b, expected",
+    [
+        (EqualNode, 2.0, 2.0, True),
+        (EqualNode, 2.0, 3.0, False),
+        (NotEqualNode, 2.0, 3.0, True),
+        (NotEqualNode, 2.0, 2.0, False),
+        (GreaterThanNode, 3.0, 2.0, True),
+        (GreaterThanNode, 2.0, 2.0, False),
+        (GreaterThanEqualNode, 2.0, 2.0, True),
+        (GreaterThanEqualNode, 1.0, 2.0, False),
+        (LessThanNode, 1.0, 2.0, True),
+        (LessThanNode, 2.0, 2.0, False),
+        (LessThanEqualNode, 2.0, 2.0, True),
+        (LessThanEqualNode, 3.0, 2.0, False),
+    ],
+)
+async def test_comparison_nodes(
+    engine: WorkflowEngine, node_cls: type, a: float, b: float, expected: bool
+):
+    assert await _run_comparison(engine, node_cls, a, b) is expected
+
+
+@pytest.mark.asyncio
+async def test_equal_default_tolerance_absorbs_rounding(engine: WorkflowEngine):
+    """0.1 + 0.2 != 0.3 under exact ==, but Equal's default rel_tol treats them equal."""
+    assert await _run_comparison(engine, EqualNode, 0.1 + 0.2, 0.3) is True
+    assert await _run_comparison(engine, NotEqualNode, 0.1 + 0.2, 0.3) is False
+
+
+@pytest.mark.asyncio
+async def test_equal_zero_rel_tol_is_exact(engine: WorkflowEngine):
+    """With rel_tol=0 and abs_tol=0, Equal falls back to exact comparison."""
+    params = {"rel_tol": 0.0, "abs_tol": 0.0}
+    assert await _run_comparison(engine, EqualNode, 0.1 + 0.2, 0.3, params) is False
+
+
+@pytest.mark.asyncio
+async def test_equal_abs_tol_near_zero(engine: WorkflowEngine):
+    """abs_tol handles values near zero where rel_tol alone is too strict."""
+    params = {"rel_tol": 0.0, "abs_tol": 1e-6}
+    assert await _run_comparison(engine, EqualNode, 0.0, 1e-9, params) is True
+    assert await _run_comparison(engine, EqualNode, 0.0, 1e-3, params) is False
+
+
+@pytest.mark.asyncio
+async def test_not_node(engine: WorkflowEngine):
+    workflow = Workflow(
+        input_node=(input_node := engine.create_input_node(a=BooleanValue)),
+        output_node=(output_node := engine.create_output_node(result=BooleanValue)),
+        inner_nodes=[node := engine.create_node(NotNode, id="not")],
+        edges=[
+            Edge.from_nodes(
+                source=input_node, source_key="a", target=node, target_key="a"
+            ),
+            Edge.from_nodes(
+                source=node,
+                source_key="result",
+                target=output_node,
+                target_key="result",
+            ),
+        ],
+    )
+    result = await engine.execute(
+        context=InMemoryExecutionContext(),
+        workflow=workflow,
+        input={"a": BooleanValue(True)},
+    )
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    assert result.output["result"].root is False
+
+
+async def _run_variadic_logic(
+    engine: WorkflowEngine, node_cls: type, values: list[bool]
+) -> bool:
+    n = len(values)
+    keys = [chr(ord("a") + i) for i in range(n)]
+    workflow = Workflow(
+        input_node=(
+            input_node := engine.create_input_node(**{k: BooleanValue for k in keys})
+        ),
+        output_node=(output_node := engine.create_output_node(result=BooleanValue)),
+        inner_nodes=[
+            logic := engine.create_node(
+                node_cls, id="logic", params=dict(num_arguments=n)
+            )
+        ],
+        edges=[
+            Edge.from_nodes(source=input_node, source_key=k, target=logic, target_key=k)
+            for k in keys
+        ]
+        + [
+            Edge.from_nodes(
+                source=logic,
+                source_key="result",
+                target=output_node,
+                target_key="result",
+            ),
+        ],
+    )
+    result = await engine.execute(
+        context=InMemoryExecutionContext(),
+        workflow=workflow,
+        input={k: BooleanValue(v) for k, v in zip(keys, values)},
+    )
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    return result.output["result"].root
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([True, True], True),
+        ([True, False], False),
+        ([True, True, True], True),
+        ([True, True, False], False),
+    ],
+)
+async def test_and_variadic(engine: WorkflowEngine, values: list[bool], expected: bool):
+    assert await _run_variadic_logic(engine, AndNode, values) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([False, False], False),
+        ([False, True], True),
+        ([False, False, False], False),
+        ([False, False, True], True),
+    ],
+)
+async def test_or_variadic(engine: WorkflowEngine, values: list[bool], expected: bool):
+    assert await _run_variadic_logic(engine, OrNode, values) is expected

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -89,17 +89,21 @@ async def test_comparison_nodes(
 
 
 @pytest.mark.asyncio
-async def test_equal_default_tolerance_absorbs_rounding(engine: WorkflowEngine):
-    """0.1 + 0.2 != 0.3 under exact ==, but Equal's default rel_tol treats them equal."""
-    assert await _run_comparison(engine, EqualNode, 0.1 + 0.2, 0.3) is True
-    assert await _run_comparison(engine, NotEqualNode, 0.1 + 0.2, 0.3) is False
+async def test_equal_default_is_exact(engine: WorkflowEngine):
+    """By default (rel_tol=0, abs_tol=0) Equal is an exact comparison."""
+    # 0.1 + 0.2 != 0.3 in binary floating point.
+    assert await _run_comparison(engine, EqualNode, 0.1 + 0.2, 0.3) is False
+    assert await _run_comparison(engine, NotEqualNode, 0.1 + 0.2, 0.3) is True
+    # Large magnitudes that differ by 1 are NOT silently treated as equal.
+    assert await _run_comparison(engine, EqualNode, 1e9, 1e9 + 1) is False
 
 
 @pytest.mark.asyncio
-async def test_equal_zero_rel_tol_is_exact(engine: WorkflowEngine):
-    """With rel_tol=0 and abs_tol=0, Equal falls back to exact comparison."""
-    params = {"rel_tol": 0.0, "abs_tol": 0.0}
-    assert await _run_comparison(engine, EqualNode, 0.1 + 0.2, 0.3, params) is False
+async def test_equal_rel_tol_absorbs_rounding(engine: WorkflowEngine):
+    """An explicit rel_tol lets Equal treat 0.1 + 0.2 and 0.3 as equal."""
+    params = {"rel_tol": 1e-9}
+    assert await _run_comparison(engine, EqualNode, 0.1 + 0.2, 0.3, params) is True
+    assert await _run_comparison(engine, NotEqualNode, 0.1 + 0.2, 0.3, params) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds built-in boolean nodes to the base engine, ported from `aceteam-nodes` against the current node-authoring conventions.

**Comparison** (two `FloatValue` inputs `a`/`b` → `BooleanValue` `result`):
`Equal`, `NotEqual`, `GreaterThan`, `GreaterThanEqual`, `LessThan`, `LessThanEqual`.

**Logic** (`BooleanValue`):
- `And` / `Or` — **variadic** like `Add`: a `num_arguments` param (default 2, min 2) drives a dynamic input type generating fields `a`, `b`, `c`, …
- `Not` — unary negation.

**Equality:** `Equal` / `NotEqual` compare with `math.isclose` and are **exact by default** (`rel_tol` and `abs_tol` both default to `0`). To absorb floating-point rounding, set `rel_tol` and/or `abs_tol` explicitly; `abs_tol` is for comparisons near zero. Tolerance is opt-in by design — a nonzero default relative tolerance scales with magnitude (e.g. `1e9` and `1e9 + 1` would compare equal), which is a footgun for count-like values.

## Conventions applied vs. the originals
- Dropped the `type: Literal[...]` overrides — discriminator is auto-derived from the class name.
- Added required `title`/`description` to all `Data`/`Params` fields.
- Relative `..core` imports; versions reset to `1.0.0` (fresh in base).

## Changes
- `src/workflow_engine/nodes/comparison.py` (new), registered/exported in `nodes/__init__.py`.
- `tests/test_comparison.py` (new) — 24 cases incl. variadic And/Or, exact-by-default behavior, and opt-in tolerance.
- `docs/nodes.md` — Comparison + Logic sections.
- `CHANGELOG.md` — Unreleased entry.

## Follow-ups
- These nodes are still registered in `aceteam-nodes` via entry points and will now collide — needs a separate removal PR there.
- Filed #151 to explore a `Decimal`-backed numeric type as the deeper fix for decimal rounding (tolerance here is the local band-aid).

## Verification
- `tests/test_comparison.py`: 24 passed. Full suite green; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)