### PR TITLE
feat(nodes): add Bash node for running shell commands

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -197,6 +197,32 @@ Appends text to a file, with an optional suffix.
 | **Parameter** `suffix` | `StringValue`   |
 | **Output** `file`      | `TextFileValue` |
 
+## Shell
+
+### Bash
+
+Runs a shell command and captures its output. The command is a Jinja template
+rendered with the node's `arguments`, so values from upstream nodes can be
+substituted in (e.g. `echo Hello {{ name }}`).
+
+> **Warning:** This node executes arbitrary shell commands in the same
+> environment as the engine itself — it is effectively remote code execution.
+> Only enable it for trusted, locally-operated engines, and never expose it on an
+> engine that runs untrusted workflows or accepts workflows over the network.
+
+| Field                          | Type                          |
+| ------------------------------ | ----------------------------- |
+| **Input** `arguments`          | `StringMapValue[StringValue]` |
+| **Parameter** `command`        | `StringValue`                 |
+| **Parameter** `combine_output` | `BooleanValue`                |
+| **Output** `stdout`            | `TextFileValue`               |
+| **Output** `stderr`            | `TextFileValue`               |
+| **Output** `exit_code`         | `IntegerValue`                |
+
+When `combine_output` is `true`, standard error is merged into standard output
+and the node produces a single `output` (`TextFileValue`) field instead of the
+separate `stdout`/`stderr` files (alongside `exit_code`).
+
 ## Error
 
 ### Error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dependencies = [
     "click>=8.3.3",
     "dotenv>=0.9.9",
+    "jinja2>=3.1.0",
     "networkx>=3.4.2,<4.0.0",
     "overrides>=7.7.0",
     "packaging>=25.0",
@@ -70,6 +71,7 @@ GatherSequence = "workflow_engine.nodes.data:GatherSequenceNode"
 Error = "workflow_engine.nodes.error:ErrorNode"
 ForEach = "workflow_engine.nodes.iteration:ForEachNode"
 AppendToFile = "workflow_engine.nodes.text:AppendToFileNode"
+Bash = "workflow_engine.nodes.shell:BashNode"
 
 [project.urls]
 Homepage = "https://aceteam.ai/workflow-engine"

--- a/src/workflow_engine/nodes/__init__.py
+++ b/src/workflow_engine/nodes/__init__.py
@@ -39,6 +39,9 @@ from .error import (
 from .iteration import (
     ForEachNode,
 )
+from .shell import (
+    BashNode,
+)
 from .text import (
     AppendToFileNode,
 )
@@ -47,6 +50,7 @@ __all__ = [
     "AddNode",
     "AndNode",
     "AppendToFileNode",
+    "BashNode",
     "ConditionalInput",
     "ConstantBooleanNode",
     "ConstantIntegerNode",

--- a/src/workflow_engine/nodes/shell.py
+++ b/src/workflow_engine/nodes/shell.py
@@ -1,0 +1,164 @@
+# workflow_engine/nodes/shell.py
+"""
+A node for running arbitrary shell commands.
+
+Every shell command can be viewed as a workflow node: a rendered command line
+runs in a subprocess, and its standard streams become output files. Arguments
+are passed into the command via Jinja substitution from the node's input.
+
+.. warning::
+    This node executes arbitrary shell commands in the same environment as the
+    engine itself. It is effectively remote code execution and must only be
+    enabled for trusted, locally-operated engines. Never expose this node on an
+    engine that runs untrusted workflows or accepts workflows over the network.
+"""
+
+import asyncio
+import os
+from typing import ClassVar, Type
+
+import jinja2
+from overrides import override
+from pydantic import Field
+
+from ..core import (
+    BooleanValue,
+    Data,
+    ExecutionContext,
+    File,
+    IntegerValue,
+    Node,
+    NodeTypeInfo,
+    Params,
+    StringMapValue,
+    StringValue,
+    ValidationContext,
+)
+from ..files import TextFileValue
+
+
+class BashInput(Data):
+    arguments: StringMapValue[StringValue] = Field(
+        title="Arguments",
+        description=(
+            "The named values substituted into the command via Jinja "
+            "(e.g. `{{ name }}`). Leave empty for commands without arguments."
+        ),
+        default=StringMapValue({}),
+    )
+
+
+class BashOutput(Data):
+    stdout: TextFileValue = Field(
+        title="Standard Output",
+        description="The text written to standard output by the command.",
+    )
+    stderr: TextFileValue = Field(
+        title="Standard Error",
+        description="The text written to standard error by the command.",
+    )
+    exit_code: IntegerValue = Field(
+        title="Exit Code",
+        description="The exit status returned by the command (0 means success).",
+    )
+
+
+class BashCombinedOutput(Data):
+    output: TextFileValue = Field(
+        title="Output",
+        description=(
+            "The combined text written to standard output and standard error "
+            "by the command."
+        ),
+    )
+    exit_code: IntegerValue = Field(
+        title="Exit Code",
+        description="The exit status returned by the command (0 means success).",
+    )
+
+
+class BashNodeParams(Params):
+    command: StringValue = Field(
+        title="Command",
+        description=(
+            "The shell command to run. Supports Jinja substitution from the "
+            "node's arguments (e.g. `echo Hello {{ name }}`)."
+        ),
+    )
+    combine_output: BooleanValue = Field(
+        title="Combine Output",
+        description=(
+            "Whether to merge standard error into standard output, producing a "
+            "single combined output file instead of separate ones."
+        ),
+        default=BooleanValue(False),
+    )
+
+
+class BashNode(Node[BashInput, Data, BashNodeParams]):
+    TYPE_INFO: ClassVar[NodeTypeInfo] = NodeTypeInfo.from_parameter_type(
+        display_name="Bash",
+        description=(
+            "Runs a shell command and captures its output. WARNING: this "
+            "executes arbitrary commands in the engine's environment and must "
+            "only be enabled for trusted, locally-operated engines."
+        ),
+        version="0.1.0",
+        parameter_type=BashNodeParams,
+    )
+
+    @classmethod
+    @override
+    def static_input_type(cls) -> Type[BashInput]:
+        return BashInput
+
+    @override
+    async def dynamic_output_type(self, context: ValidationContext) -> Type[Data]:
+        if self.params.combine_output.root:
+            return BashCombinedOutput
+        return BashOutput
+
+    @override
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        input_type: Type[BashInput],
+        output_type: Type[Data],
+        input: BashInput,
+    ) -> Data:
+        arguments = {key: value.root for key, value in input.arguments.items()}
+        template = jinja2.Template(
+            self.params.command.root, undefined=jinja2.StrictUndefined
+        )
+        command = template.render(**arguments)
+
+        shell = os.environ.get("SHELL") or "/bin/bash"
+        combine = self.params.combine_output.root
+        process = await asyncio.create_subprocess_exec(
+            shell,
+            "-c",
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=(asyncio.subprocess.STDOUT if combine else asyncio.subprocess.PIPE),
+        )
+        stdout_bytes, stderr_bytes = await process.communicate()
+        exit_code = IntegerValue(process.returncode or 0)
+
+        stdout_text = (stdout_bytes or b"").decode("utf-8", errors="replace")
+        if combine:
+            output_file = TextFileValue(File(path=f"{self.id}.output.txt"))
+            output_file = await output_file.write_text(context, text=stdout_text)
+            return BashCombinedOutput(output=output_file, exit_code=exit_code)
+
+        stderr_text = (stderr_bytes or b"").decode("utf-8", errors="replace")
+        stdout_file = TextFileValue(File(path=f"{self.id}.stdout.txt"))
+        stdout_file = await stdout_file.write_text(context, text=stdout_text)
+        stderr_file = TextFileValue(File(path=f"{self.id}.stderr.txt"))
+        stderr_file = await stderr_file.write_text(context, text=stderr_text)
+        return BashOutput(stdout=stdout_file, stderr=stderr_file, exit_code=exit_code)
+
+
+__all__ = [
+    "BashNode",
+]

--- a/src/workflow_engine/nodes/shell.py
+++ b/src/workflow_engine/nodes/shell.py
@@ -17,7 +17,7 @@ import asyncio
 import os
 from typing import ClassVar, Type
 
-import jinja2
+from jinja2 import StrictUndefined, Template
 from overrides import override
 from pydantic import Field
 
@@ -128,8 +128,11 @@ class BashNode(Node[BashInput, Data, BashNodeParams]):
         input: BashInput,
     ) -> Data:
         arguments = {key: value.root for key, value in input.arguments.items()}
-        template = jinja2.Template(
-            self.params.command.root, undefined=jinja2.StrictUndefined
+        # NOTE: Template annotation is needed because Template.__new__ is typed
+        # as returning Any to avoid breaking Sphinx.
+        template: Template = Template(
+            self.params.command.root,
+            undefined=StrictUndefined,
         )
         command = template.render(**arguments)
 
@@ -143,20 +146,31 @@ class BashNode(Node[BashInput, Data, BashNodeParams]):
             stderr=(asyncio.subprocess.STDOUT if combine else asyncio.subprocess.PIPE),
         )
         stdout_bytes, stderr_bytes = await process.communicate()
-        exit_code = IntegerValue(process.returncode or 0)
+        assert process.returncode is not None, (
+            "process.returncode was None after communicate()"
+        )
 
-        stdout_text = (stdout_bytes or b"").decode("utf-8", errors="replace")
+        exit_code = IntegerValue(process.returncode)
+
+        stdout_text = stdout_bytes.decode("utf-8", errors="replace")
         if combine:
             output_file = TextFileValue(File(path=f"{self.id}.output.txt"))
             output_file = await output_file.write_text(context, text=stdout_text)
-            return BashCombinedOutput(output=output_file, exit_code=exit_code)
+            return BashCombinedOutput(
+                output=output_file,
+                exit_code=exit_code,
+            )
 
-        stderr_text = (stderr_bytes or b"").decode("utf-8", errors="replace")
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
         stdout_file = TextFileValue(File(path=f"{self.id}.stdout.txt"))
         stdout_file = await stdout_file.write_text(context, text=stdout_text)
         stderr_file = TextFileValue(File(path=f"{self.id}.stderr.txt"))
         stderr_file = await stderr_file.write_text(context, text=stderr_text)
-        return BashOutput(stdout=stdout_file, stderr=stderr_file, exit_code=exit_code)
+        return BashOutput(
+            stdout=stdout_file,
+            stderr=stderr_file,
+            exit_code=exit_code,
+        )
 
 
 __all__ = [

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,154 @@
+import pytest
+
+from workflow_engine import (
+    Edge,
+    IntegerValue,
+    StringValue,
+    Workflow,
+    WorkflowEngine,
+    WorkflowExecutionResultStatus,
+)
+from workflow_engine.contexts import InMemoryExecutionContext
+from workflow_engine.core import StringMapValue
+from workflow_engine.files import TextFileValue
+from workflow_engine.nodes import BashNode
+
+
+@pytest.fixture
+def engine() -> WorkflowEngine:
+    return WorkflowEngine()
+
+
+async def _read(result, key: str, context: InMemoryExecutionContext) -> str:
+    value = result.output[key]
+    assert isinstance(value, TextFileValue)
+    return await value.read_text(context)
+
+
+def _separate_workflow(engine: WorkflowEngine, command: str) -> Workflow:
+    return Workflow(
+        input_node=engine.create_input_node(),
+        output_node=(
+            output_node := engine.create_output_node(
+                stdout=TextFileValue,
+                stderr=TextFileValue,
+                exit_code=IntegerValue,
+            )
+        ),
+        inner_nodes=[
+            bash := engine.create_node(
+                BashNode,
+                id="bash",
+                params=dict(command=command),
+            ),
+        ],
+        edges=[
+            Edge.from_nodes(
+                source=bash, source_key=key, target=output_node, target_key=key
+            )
+            for key in ("stdout", "stderr", "exit_code")
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_basic_command(engine: WorkflowEngine):
+    context = InMemoryExecutionContext()
+    workflow = _separate_workflow(engine, "echo hello")
+
+    result = await engine.execute(context=context, workflow=workflow, input={})
+
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    assert (await _read(result, "stdout", context)) == "hello\n"
+    assert (await _read(result, "stderr", context)) == ""
+    assert result.output["exit_code"].root == 0
+
+
+@pytest.mark.asyncio
+async def test_jinja_arguments(engine: WorkflowEngine):
+    context = InMemoryExecutionContext()
+    workflow = Workflow(
+        input_node=(
+            input_node := engine.create_input_node(
+                arguments=StringMapValue[StringValue],
+            )
+        ),
+        output_node=(output_node := engine.create_output_node(stdout=TextFileValue)),
+        inner_nodes=[
+            bash := engine.create_node(
+                BashNode,
+                id="bash",
+                params=dict(command="echo Hello {{ name }}"),
+            ),
+        ],
+        edges=[
+            Edge.from_nodes(
+                source=input_node,
+                source_key="arguments",
+                target=bash,
+                target_key="arguments",
+            ),
+            Edge.from_nodes(
+                source=bash,
+                source_key="stdout",
+                target=output_node,
+                target_key="stdout",
+            ),
+        ],
+    )
+
+    result = await engine.execute(
+        context=context,
+        workflow=workflow,
+        input={"arguments": StringMapValue({"name": StringValue("world")})},
+    )
+
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    assert (await _read(result, "stdout", context)) == "Hello world\n"
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_and_stderr(engine: WorkflowEngine):
+    context = InMemoryExecutionContext()
+    workflow = _separate_workflow(engine, "echo oops >&2; exit 3")
+
+    result = await engine.execute(context=context, workflow=workflow, input={})
+
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    assert (await _read(result, "stderr", context)) == "oops\n"
+    assert result.output["exit_code"].root == 3
+
+
+@pytest.mark.asyncio
+async def test_combined_output(engine: WorkflowEngine):
+    context = InMemoryExecutionContext()
+    workflow = Workflow(
+        input_node=engine.create_input_node(),
+        output_node=(
+            output_node := engine.create_output_node(
+                output=TextFileValue,
+                exit_code=IntegerValue,
+            )
+        ),
+        inner_nodes=[
+            bash := engine.create_node(
+                BashNode,
+                id="bash",
+                params=dict(
+                    command="echo out; echo err >&2",
+                    combine_output=True,
+                ),
+            ),
+        ],
+        edges=[
+            Edge.from_nodes(
+                source=bash, source_key=key, target=output_node, target_key=key
+            )
+            for key in ("output", "exit_code")
+        ],
+    )
+
+    result = await engine.execute(context=context, workflow=workflow, input={})
+
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    assert (await _read(result, "output", context)) == "out\nerr\n"

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "dotenv" },
+    { name = "jinja2" },
     { name = "networkx" },
     { name = "overrides" },
     { name = "packaging" },
@@ -35,6 +36,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "jinja2", specifier = ">=3.1.0" },
     { name = "networkx", specifier = ">=3.4.2,<4.0.0" },
     { name = "overrides", specifier = ">=7.7.0" },
     { name = "packaging", specifier = ">=25.0" },
@@ -349,6 +351,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -375,6 +389,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #157.

Implements the idea from #157: every shell command can be viewed as a workflow node with arguments in and its standard streams as output files.

## What's new

`BashNode` (`type: "Bash"`):

- **`command`** param — the shell command, rendered as a **Jinja template** so values from upstream nodes substitute in via `{{ name }}` (`StrictUndefined`, so a missing variable errors instead of blanking).
- **`combine_output`** param — when `true`, merges stderr into stdout (`2>&1`) and switches the node's output shape to a single combined `output` file (via `dynamic_output_type`), as described in the issue.
- **`arguments`** input — a `StringMapValue[StringValue]` (defaults empty, so argument-free commands need no edge) supplying the Jinja variables.
- **Outputs** — `stdout` + `stderr` files and an `exit_code`, or a single `output` file + `exit_code` when combining.
- Runs in the user's `$SHELL` (falls back to `/bin/bash`) in the engine's own environment, matching the maintainer discussion on the issue.

## Security

This is effectively **remote code execution** — it runs arbitrary commands in the engine's environment. The node/module descriptions and docs flag it as **trusted, locally-operated engines only**; never expose it on an engine that runs untrusted workflows or accepts workflows over the network.

## Notes / open questions

- **Non-zero exits don't raise** — `exit_code` is just an output, leaving failure handling to downstream nodes. Happy to add a `check` param that raises on non-zero if preferred.
- **`.bashrc` sourcing** — the issue mused about full interactive-shell init. This uses a plain non-interactive `bash -c` (no `-i`/`-l`) to avoid hangs and job-control noise; users add init via `&&` as the issue suggests.

## Testing

New `tests/test_shell.py` (4 tests): basic command, Jinja arg substitution through an input edge, non-zero exit + stderr capture, combined output. Full suite green: ruff (check + format), pyright (0 errors), 648 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)