### PR TITLE
feat(context): async get_env on ValidationContext + ExecutionContext

### DIFF
--- a/src/workflow_engine/core/context.py
+++ b/src/workflow_engine/core/context.py
@@ -5,6 +5,7 @@ from typing import TypeVar
 
 from overrides import EnforceOverrides
 
+from ..utils.env import get_env as _resolve_env_var
 from .error import ShouldRetry, ShouldYield, WorkflowErrors, WorkflowException
 from .execution import WorkflowExecutionResult
 from .node import Node, NodeRegistry
@@ -31,6 +32,26 @@ class ValidationContext:
         self.node_registry = node_registry
         self.value_registry = value_registry
 
+    async def get_env(self, key: str, default: str | None = None) -> str:
+        """
+        Resolve an environment variable for use during validation or execution.
+
+        The default implementation reads from the process environment (a loaded
+        ``.env`` file included), returning ``default`` when the variable is
+        unset and raising ``ValueError`` when it is unset and no default is
+        given.
+
+        This is the single source of environment resolution; ``ExecutionContext``
+        delegates here. The method is awaitable so that interactive contexts can
+        raise ``ShouldYield`` to pause execution and ask the user to supply a
+        missing variable (returning the now-provided value on resume), or fetch
+        secrets from an external store.
+
+        key: the environment variable name
+        default: value to return when the variable is unset
+        """
+        return _resolve_env_var(key, default=default)
+
 
 class ExecutionContext(ABC, EnforceOverrides):
     """
@@ -45,6 +66,20 @@ class ExecutionContext(ABC, EnforceOverrides):
         if validation_context is None:
             validation_context = ValidationContext()
         self.validation_context = validation_context
+
+    async def get_env(self, key: str, default: str | None = None) -> str:
+        """
+        Resolve an environment variable, delegating to the validation context.
+
+        Nodes call this to obtain credentials and configuration at runtime. The
+        underlying implementation may raise ``ShouldYield`` to pause execution
+        and request a missing variable from the user; see
+        ``ValidationContext.get_env``.
+
+        key: the environment variable name
+        default: value to return when the variable is unset
+        """
+        return await self.validation_context.get_env(key, default=default)
 
     @abstractmethod
     async def read(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,62 @@
+# tests/test_env.py
+"""Tests for environment-variable resolution on the context classes.
+
+``ValidationContext.get_env`` is the single resolver; ``ExecutionContext.get_env``
+delegates to it. Both are awaitable so that interactive contexts can raise
+``ShouldYield`` to pause and request a missing variable from the user.
+"""
+
+import pytest
+from overrides import override
+
+from workflow_engine import ShouldYield
+from workflow_engine.contexts import InMemoryExecutionContext
+from workflow_engine.core.context import ValidationContext
+
+
+class TestValidationContextGetEnv:
+    @pytest.mark.asyncio
+    async def test_returns_set_variable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("WENGINE_TEST_VAR", "value")
+        assert await ValidationContext().get_env("WENGINE_TEST_VAR") == "value"
+
+    @pytest.mark.asyncio
+    async def test_returns_default_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("WENGINE_TEST_VAR", raising=False)
+        assert (
+            await ValidationContext().get_env("WENGINE_TEST_VAR", "fallback")
+            == "fallback"
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_when_unset_without_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("WENGINE_TEST_VAR", raising=False)
+        with pytest.raises(ValueError):
+            await ValidationContext().get_env("WENGINE_TEST_VAR")
+
+
+class TestExecutionContextDelegates:
+    @pytest.mark.asyncio
+    async def test_delegates_to_validation_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("WENGINE_TEST_VAR", "value")
+        context = InMemoryExecutionContext()
+        assert await context.get_env("WENGINE_TEST_VAR") == "value"
+
+    @pytest.mark.asyncio
+    async def test_yield_propagates_through_execution_context(self):
+        """An interactive validation context can pause resolution via ShouldYield."""
+
+        class InteractiveValidationContext(ValidationContext):
+            @override
+            async def get_env(self, key: str, default: str | None = None) -> str:
+                raise ShouldYield(f"waiting for {key}")
+
+        context = InMemoryExecutionContext(
+            validation_context=InteractiveValidationContext()
+        )
+        with pytest.raises(ShouldYield):
+            await context.get_env("NEEDS_USER_INPUT")


### PR DESCRIPTION
## Context

Nodes increasingly need to resolve credentials and configuration at runtime — e.g. an integration node that sends a message needs a bot token, without baking the secret into the workflow definition. There's no uniform way to do that today: `get_env` only exists downstream on `AceTeamContext`, so node packages can't code against it.

This adds environment resolution to the engine's context layer so any node can call `await context.get_env(...)` regardless of which concrete context it's running under.

## Summary

- **`ValidationContext.get_env(key, default=None) -> str`** — the single resolver. Reads the process environment (loaded `.env` included), returns `default` when unset, raises `ValueError` when unset with no default. Reuses the existing `utils.env.get_env`.
- **`ExecutionContext.get_env`** — delegates to `self.validation_context.get_env`. The execution context always holds a validation context, so there's one source of truth.
- **Both are `async`.** This is deliberate: an interactive context can override `get_env` to raise `ShouldYield`, pausing execution to ask the user for a missing variable and returning the supplied value on resume — or fetch secrets from an external store. The default (non-interactive) contexts just read the environment synchronously under the hood.

`LocalContext` and `InMemoryExecutionContext` inherit the default for free; no exports change.

## Test plan

`tests/test_env.py` (5 tests, all green):

| Group | Coverage |
| --- | --- |
| `ValidationContext.get_env` | returns a set var; returns the default when unset; raises `ValueError` when unset with no default |
| `ExecutionContext` delegation | resolves through the validation context |
| `ShouldYield` | an interactive validation context that raises `ShouldYield` propagates cleanly through `ExecutionContext.get_env` |

Existing `test_hooks.py` + `test_yield.py` (57 tests) still pass; ruff clean.

## Related

First piece of the "MCP tools as workflow nodes" effort — unblocks credential-decoupled integration nodes in `aceteam-nodes`. The node→MCP-tool bridge and the python-backend wengine bump follow once this lands.

---
*Generated by Claude*