### PR TITLE
Back FloatValue with Decimal for exact decimal arithmetic

### DIFF
--- a/src/workflow_engine/core/values/data.py
+++ b/src/workflow_engine/core/values/data.py
@@ -2,9 +2,9 @@
 import json
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Generic, TypeVar
 
-from pydantic import ConfigDict, create_model
+from pydantic import ConfigDict, PlainSerializer, create_model
 from pydantic.fields import FieldInfo
 
 from ...utils.asynchronous import gather
@@ -20,7 +20,24 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-type DataMapping = Mapping[str, Value]
+def dump_data_mapping(data: Mapping[str, Value]) -> Mapping[str, Any]:
+    return {k: v.model_dump(mode="json") for k, v in data.items()}
+
+
+# Pydantic fields typed Mapping[str, Value] do not dispatch to each value's own
+# JSON serializers (e.g. FloatValue's PlainSerializer on _DecimalRoot).
+# Serialization sees the static Value base type and dumps roots directly,
+# e.g. Decimal would become a JSON string.
+# dump_data_mapping calls model_dump(mode="json") on every concrete Value
+# instance so leaf types control their own wire format.
+type DataMapping = Annotated[
+    Mapping[str, Value],
+    PlainSerializer(
+        dump_data_mapping,
+        return_type=Mapping[str, Any],
+        when_used="json",
+    ),
+]
 
 
 class Data(ImmutableBaseModel):
@@ -77,11 +94,7 @@ def get_only_field(cls: type[Data]) -> tuple[str, type[Value]]:
     return only(fields.items())
 
 
-def dump_data_mapping(data: DataMapping) -> Mapping[str, Any]:
-    return {k: v.model_dump() for k, v in data.items()}
-
-
-def serialize_data_mapping(data: DataMapping) -> str:
+def serialize_data_mapping(data: Mapping[str, Value]) -> str:
     return json.dumps(dump_data_mapping(data))
 
 

--- a/src/workflow_engine/core/values/decimal_utils.py
+++ b/src/workflow_engine/core/values/decimal_utils.py
@@ -1,0 +1,33 @@
+# workflow_engine/core/values/decimal_utils.py
+"""Helpers for exact decimal numeric values."""
+
+from decimal import Decimal
+
+
+def to_decimal(value: int | float | Decimal | str) -> Decimal:
+    """
+    Convert a numeric value to Decimal without unnecessary float round-trips.
+
+    Integers and Decimals pass through exactly. Floats and strings are converted
+    via ``Decimal(str(value))``, matching Pydantic's Decimal coercion and
+    preserving common decimal literals like ``0.1`` when sourced from JSON text.
+
+    Do not replace float handling with bare ``Decimal(value)``: that encodes the
+    float's exact IEEE-754 bits (e.g. ``Decimal(3.14)`` →
+    ``3.1400000000000001243...``), while ``str(3.14)`` is the shortest decimal
+    that round-trips back to the same float, so ``Decimal(str(3.14))`` →
+    ``3.14`` — which is what ``FloatValue(3.14)`` stores and what ``__eq__``
+    against ``3.14`` must match.
+    """
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return Decimal(value)
+    if isinstance(value, float):
+        return Decimal(str(value))
+    if isinstance(value, str):
+        return Decimal(value)
+    raise ValueError(f"Expected int, float, Decimal, or str, got {type(value)}")
+
+
+__all__ = ("to_decimal",)

--- a/src/workflow_engine/core/values/json.py
+++ b/src/workflow_engine/core/values/json.py
@@ -1,6 +1,7 @@
 # workflow_engine/core/values/json.py
 
 from collections.abc import Mapping, Sequence
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from .mapping import StringMapValue
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
     from ..context import ExecutionContext
 
 
-type JSON = Mapping[str, JSON] | Sequence[JSON] | None | bool | int | float | str
+type JSON = Mapping[str, JSON] | Sequence[JSON] | None | bool | int | Decimal | str
 
 
 class JSONValue(Value[JSON]):
@@ -48,10 +49,12 @@ def cast_json_to_integer(value: JSONValue, context: "ExecutionContext") -> Integ
 
 @JSONValue.register_cast_to(FloatValue)
 def cast_json_to_float(value: JSONValue, context: "ExecutionContext") -> FloatValue:
-    # Accept both int and float, but not bool
-    if isinstance(value.root, (int, float)) and not isinstance(value.root, bool):
-        return FloatValue(float(value.root))
-    raise ValueError(f"Expected float or int, got {type(value.root)}")
+    root = value.root
+    if isinstance(root, bool):
+        raise ValueError(f"Expected float or int, got {type(root)}")
+    if isinstance(root, (int, Decimal)):
+        return FloatValue(root)
+    raise ValueError(f"Expected float or int, got {type(root)}")
 
 
 @JSONValue.register_generic_cast_to(SequenceValue)

--- a/src/workflow_engine/core/values/primitives.py
+++ b/src/workflow_engine/core/values/primitives.py
@@ -2,21 +2,99 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from decimal import Decimal
+from typing import TYPE_CHECKING, Annotated
 
+from pydantic import (
+    BeforeValidator,
+    GetJsonSchemaHandler,
+    PlainSerializer,
+    ValidationError,
+)
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema
+
+from ...utils.iter import only
+from .decimal_utils import to_decimal
 from .value import Value
 
 if TYPE_CHECKING:
     from ..context import ExecutionContext
 
 
+def _serialize_decimal_for_json(value: Decimal) -> float:
+    return float(value)
+
+
+_NUMERIC_SCHEMA_ALIASES = {
+    "ge": "minimum",
+    "le": "maximum",
+    "gt": "exclusiveMinimum",
+    "lt": "exclusiveMaximum",
+    "multiple_of": "multipleOf",
+}
+
+
+class _FlattenDecimalJsonSchema:
+    """Pydantic emits Decimal as anyOf[number, string]; we want plain type: number."""
+
+    def __get_pydantic_json_schema__(
+        self,
+        core_schema: core_schema.CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        if "anyOf" not in json_schema:
+            return json_schema
+        number_schema = only(
+            item for item in json_schema["anyOf"] if item.get("type") == "number"
+        )
+        result = dict(number_schema)
+        for key, value in json_schema.items():
+            if key == "anyOf":
+                continue
+            out_key = _NUMERIC_SCHEMA_ALIASES.get(key, key)
+            if out_key == "type" and "type" in result:
+                continue
+            result[out_key] = value
+        return result
+
+
+_DecimalRoot = Annotated[
+    Decimal,
+    BeforeValidator(to_decimal),
+    PlainSerializer(_serialize_decimal_for_json, return_type=float, when_used="json"),
+    _FlattenDecimalJsonSchema(),
+]
+
+
 class BooleanValue(Value[bool]):
     pass
 
 
-class FloatValue(Value[float]):
+class FloatValue(Value[_DecimalRoot]):
     def is_integer(self) -> bool:
-        return self.root.is_integer()
+        return self.root == self.root.to_integral_value()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Value):
+            return self.root == other.root
+        if isinstance(other, bool):
+            return False
+        try:
+            return self.root == FloatValue(other).root
+        except ValidationError:
+            return False
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        extras = cls.model_config.get("json_schema_extra")
+        if extras:
+            json_schema = {**json_schema, **extras}
+        return json_schema
 
 
 class IntegerValue(Value[int]):
@@ -40,46 +118,56 @@ class StringValue(Value[str]):
 
 @IntegerValue.register_cast_to(FloatValue)
 def cast_integer_to_float(
-    value: IntegerValue, context: "ExecutionContext"
+    value: IntegerValue,
+    context: "ExecutionContext",
 ) -> FloatValue:
-    return FloatValue(float(value.root))
+    return FloatValue(value.root)
 
 
 @FloatValue.register_cast_to(IntegerValue)
 def cast_float_to_integer(
-    value: FloatValue, context: "ExecutionContext"
+    value: FloatValue,
+    context: "ExecutionContext",
 ) -> IntegerValue:
     """
     Convert a float to an integer only if the float is already an integer.
     Otherwise, raise a ValueError.
     """
-    if value.root.is_integer():
+    if value.is_integer():
         return IntegerValue(int(value.root))
     else:
         raise ValueError(f"Cannot convert {value} to {IntegerValue}")
 
 
 @Value.register_cast_to(StringValue)
-def cast_value_to_string(value: Value, context: "ExecutionContext") -> StringValue:
+def cast_value_to_string(
+    value: Value,
+    context: "ExecutionContext",
+) -> StringValue:
     return StringValue(str(value.root))
 
 
 @StringValue.register_cast_to(BooleanValue)
 def cast_string_to_boolean(
-    value: StringValue, context: "ExecutionContext"
+    value: StringValue,
+    context: "ExecutionContext",
 ) -> BooleanValue:
     return BooleanValue.model_validate_json(value.root)
 
 
 @StringValue.register_cast_to(IntegerValue)
 def cast_string_to_integer(
-    value: StringValue, context: "ExecutionContext"
+    value: StringValue,
+    context: "ExecutionContext",
 ) -> IntegerValue:
     return IntegerValue.model_validate_json(value.root)
 
 
 @StringValue.register_cast_to(FloatValue)
-def cast_string_to_float(value: StringValue, context: "ExecutionContext") -> FloatValue:
+def cast_string_to_float(
+    value: StringValue,
+    context: "ExecutionContext",
+) -> FloatValue:
     return FloatValue.model_validate_json(value.root)
 
 

--- a/src/workflow_engine/files/json.py
+++ b/src/workflow_engine/files/json.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 from collections.abc import Sequence
+from decimal import Decimal
 from logging import getLogger
 from typing import Any, ClassVar, Self, Type
 
@@ -41,7 +42,7 @@ class JSONFileValue(TextFileValue):
     mime_type: ClassVar[str] = "application/json"
 
     async def read_data(self, context: "ExecutionContext") -> Any:
-        return json.loads(await self.read_text(context))
+        return json.loads(await self.read_text(context), parse_float=Decimal)
 
     async def write_data(self, context: "ExecutionContext", data: Any) -> Self:
         text = json.dumps(data, default=_custom_json_serializer)
@@ -80,17 +81,19 @@ async def cast_json_file_to_integer(
 
 @JSONFileValue.register_cast_to(FloatValue)
 async def cast_json_file_to_float(
-    value: JSONFileValue, context: "ExecutionContext"
+    value: JSONFileValue,
+    context: "ExecutionContext",
 ) -> FloatValue:
     data = await value.read_data(context)
-    if isinstance(data, float):
+    if isinstance(data, (Decimal, int)):
         return FloatValue(data)
-    raise ValueError(f"Expected float, got {type(data)}")
+    raise ValueError(f"Expected number, got {type(data)}")
 
 
 @JSONFileValue.register_cast_to(StringValue)
 async def cast_json_file_to_string(
-    value: JSONFileValue, context: "ExecutionContext"
+    value: JSONFileValue,
+    context: "ExecutionContext",
 ) -> StringValue:
     data = await value.read_data(context)
     if isinstance(data, str):
@@ -130,14 +133,16 @@ def cast_json_file_to_string_map(
 
 @JSONFileValue.register_cast_to(JSONValue)
 async def cast_json_file_to_json(
-    value: JSONFileValue, context: "ExecutionContext"
+    value: JSONFileValue,
+    context: "ExecutionContext",
 ) -> JSONValue:
     return JSONValue(await value.read_data(context))
 
 
 @Value.register_cast_to(JSONFileValue)
 async def cast_any_to_json_file(
-    value: Value, context: "ExecutionContext"
+    value: Value,
+    context: "ExecutionContext",
 ) -> JSONFileValue:
     if isinstance(value, JSONFileValue):
         return value
@@ -160,7 +165,8 @@ class JSONLinesFileValue(TextFileValue):
 
     async def read_data(self, context: "ExecutionContext") -> Sequence[Any]:
         return [
-            json.loads(line) for line in (await self.read_text(context)).splitlines()
+            json.loads(line, parse_float=Decimal)
+            for line in (await self.read_text(context)).splitlines()
         ]
 
     async def write_data(

--- a/tests/test_addition.py
+++ b/tests/test_addition.py
@@ -240,3 +240,45 @@ async def test_workflow_execution(engine: WorkflowEngine, workflow: Workflow):
     )
     assert result.status is WorkflowExecutionResultStatus.SUCCESS
     assert result.output == {"sum": 42 + 2025 + c}
+
+
+@pytest.mark.asyncio
+async def test_add_exact_decimal_fractions(engine: WorkflowEngine):
+    """AddNode sums decimal fractions exactly (0.1 + 0.2 == 0.3)."""
+    workflow = Workflow(
+        input_node=(input_node := engine.create_input_node(a=FloatValue, b=FloatValue)),
+        output_node=(output_node := engine.create_output_node(sum=FloatValue)),
+        inner_nodes=[add := engine.create_node(AddNode, id="add")],
+        edges=[
+            Edge.from_nodes(
+                source=input_node,
+                source_key="a",
+                target=add,
+                target_key="a",
+            ),
+            Edge.from_nodes(
+                source=input_node,
+                source_key="b",
+                target=add,
+                target_key="b",
+            ),
+            Edge.from_nodes(
+                source=add,
+                source_key="sum",
+                target=output_node,
+                target_key="sum",
+            ),
+        ],
+    )
+
+    context = InMemoryExecutionContext()
+    result = await engine.execute(
+        context=context,
+        workflow=workflow,
+        input={
+            "a": 0.1,
+            "b": 0.2,
+        },
+    )
+    assert result.status is WorkflowExecutionResultStatus.SUCCESS
+    assert result.output["sum"] == 0.3

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Literal
 
 import pytest
@@ -504,13 +505,13 @@ async def test_json_value_to_float(context):
     json_float = JSONValue(3.14)
     float_val = await json_float.cast_to(FloatValue, context=context)
     assert isinstance(float_val, FloatValue)
-    assert float_val.root == 3.14
+    assert float_val == 3.14
 
     # Successful cast from int (int should be accepted for float)
     json_int = JSONValue(42)
     float_val = await json_int.cast_to(FloatValue, context=context)
     assert isinstance(float_val, FloatValue)
-    assert float_val.root == 42.0
+    assert float_val == 42.0
 
     # Failed casts - bool should not cast to float
     with pytest.raises(ValueError, match="Expected float or int"):
@@ -646,6 +647,14 @@ async def test_json_value_type_checking_strictness(context):
     json_int = JSONValue(1)
     with pytest.raises(ValueError, match="Expected bool"):
         await json_int.cast_to(BooleanValue, context=context)
+
+
+@pytest.mark.unit
+def test_float_value_exact_decimal_arithmetic():
+    """FloatValue uses Decimal so 0.1 + 0.2 is exactly 0.3."""
+    a = FloatValue(0.1)
+    b = FloatValue(0.2)
+    assert a.root + b.root == Decimal("0.3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Store `FloatValue` as `Decimal` via `BeforeValidator(to_decimal)` on `_DecimalRoot`, with annotated JSON serialization and schema flattening so wire format stays `"type": "number"`.
- Parse JSON file numbers with `parse_float=Decimal`; add `DataMapping` JSON serializer so polymorphic `Mapping[str, Value]` fields dispatch per-value `model_dump(mode="json")`.
- Fixes the `0.1 + 0.2 == 0.3` class of rounding bugs through workflow input → arithmetic → output (closes #151).

## Test plan

- [x] `pytest tests/` (650 passed, 1 xfail)
- [x] `test_add_exact_decimal_fractions` — workflow input `{"a": 0.1, "b": 0.2}` → sum `0.3`
- [x] `test_float_value_exact_decimal_arithmetic` — unit test for Decimal addition


Made with [Cursor](https://cursor.com)