### PR TITLE
Adopt node performance improvements from autoresearch

### DIFF
--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -355,7 +355,9 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
         input_fields = get_data_fields(input_type)
         allow_extra_input = input_type.model_config.get("extra", "forbid") == "allow"
 
-        # Validate all inputs first
+        # Validate castability and collect cast tasks
+        cast_tasks: list[Awaitable[Value]] = []
+        keys: list[str] = []
         for key, value in input.items():
             if key not in input_fields:
                 if allow_extra_input:
@@ -371,22 +373,13 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
                     node=self,
                 )
 
-        # Cast all inputs in parallel
-        cast_tasks: list[Awaitable[Value]] = []
-        keys: list[str] = []
-        for key, value in input.items():
-            if key not in input_fields and allow_extra_input:
-                continue
-            input_field_type, _ = input_fields[key]  # type: ignore
             cast_tasks.append(value.cast_to(input_field_type, context=context))
             keys.append(key)
 
         casted_values = await gather(cast_tasks)
 
         # Build the result dictionary
-        casted_input: dict[str, Value] = {}
-        for key, casted_value in zip(keys, casted_values):
-            casted_input[key] = casted_value
+        casted_input = dict(zip(keys, casted_values))
 
         try:
             return input_type.model_validate(casted_input)

--- a/src/workflow_engine/core/node.py
+++ b/src/workflow_engine/core/node.py
@@ -356,8 +356,9 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
         allow_extra_input = input_type.model_config.get("extra", "forbid") == "allow"
 
         # Validate castability and collect cast tasks
+        casted_input: dict[str, Value] = {}
+        cast_keys: list[str] = []
         cast_tasks: list[Awaitable[Value]] = []
-        keys: list[str] = []
         for key, value in input.items():
             if key not in input_fields:
                 if allow_extra_input:
@@ -373,13 +374,19 @@ class Node(ImmutableBaseModel, Generic[Input_contra, Output, Params_co]):
                     node=self,
                 )
 
-            cast_tasks.append(value.cast_to(input_field_type, context=context))
-            keys.append(key)
+            # avoid asyncio overhead by keeping original value
+            if isinstance(value, input_field_type):
+                casted_input[key] = value
+            else:
+                cast_tasks.append(value.cast_to(input_field_type, context=context))
+                cast_keys.append(key)
 
         casted_values = await gather(cast_tasks)
 
         # Build the result dictionary
-        casted_input = dict(zip(keys, casted_values))
+        for key, value in zip(cast_keys, casted_values):
+            assert key not in casted_input
+            casted_input[key] = value
 
         try:
             return input_type.model_validate(casted_input)


### PR DESCRIPTION
This PR cherrypicks 001 and 005 from #92, for two nice performance improvements which collectively save about 17% of time on some performance benchmarks from that PR. Both changes apply to `node.py`

1. loop over the inputs once instead of twice
2. only cast values which actually need it (don't cast values that are already of the target type)