### PR TITLE
Speed up execution scheduling with incremental ready-node tracking

### DIFF
--- a/src/workflow_engine/core/workflow.py
+++ b/src/workflow_engine/core/workflow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence, Set
 from functools import cached_property
 from typing import TYPE_CHECKING, Awaitable, Self, Type
 
@@ -65,6 +65,14 @@ class Workflow(ImmutableBaseModel):
                 )
             edges_by_target[edge.target_id][edge.target_key] = edge
         return edges_by_target
+
+    @cached_property
+    def successors_by_source(self) -> Mapping[str, Set[str]]:
+        """A mapping from each node to the set of nodes that depend on it."""
+        successors: dict[str, set[str]] = {node.id: set() for node in self.nodes}
+        for edge in self.edges:
+            successors[edge.source_id].add(edge.target_id)
+        return successors
 
     @cached_property
     def nx_graph(self) -> nx.DiGraph:
@@ -236,6 +244,60 @@ class ValidatedWorkflow(Workflow):
     def output_type(self) -> Type[Data]:
         return self.node_output_types[self.output_node.id]
 
+    def get_node_input_if_ready(
+        self,
+        node_id: str,
+        node_outputs: Mapping[str, DataMapping],
+    ) -> DataMapping | None:
+        """
+        Build a node's input from completed upstream outputs, or None if not ready.
+        """
+        node_edges = self.edges_by_target.get(node_id)
+        if node_edges is None or len(node_edges) == 0:
+            return {}
+        node_input: DataMapping = {}
+        for target_key, edge in node_edges.items():
+            source_output = node_outputs.get(edge.source_id)
+            if source_output is None:
+                return None
+            node_input[target_key] = get_value_at_path(
+                data=source_output,
+                path=edge.source_key_path,
+            )
+        return node_input
+
+    def get_initial_ready_nodes(self, input: DataMapping) -> Mapping[str, DataMapping]:
+        """
+        Return all nodes ready to execute at workflow start, including the input node.
+        """
+        return {
+            **self.get_ready_nodes(node_outputs={}),
+            self.input_node.id: input,
+        }
+
+    def get_ready_successors(
+        self,
+        completed_node_ids: Iterable[str],
+        node_outputs: Mapping[str, DataMapping],
+        *,
+        skip: Set[str] = frozenset(),
+    ) -> Mapping[str, DataMapping]:
+        """
+        Return newly ready successor nodes after the given nodes complete.
+
+        Only checks direct successors of completed_node_ids. Nodes in skip are
+        ignored, as are nodes already present in the returned map.
+        """
+        ready_nodes: dict[str, DataMapping] = {}
+        for completed_id in completed_node_ids:
+            for succ_id in self.successors_by_source.get(completed_id, ()):
+                if succ_id in node_outputs or succ_id in skip or succ_id in ready_nodes:
+                    continue
+                succ_input = self.get_node_input_if_ready(succ_id, node_outputs)
+                if succ_input is not None:
+                    ready_nodes[succ_id] = succ_input
+        return ready_nodes
+
     def get_ready_nodes(
         self,
         node_outputs: Mapping[str, DataMapping] | None = None,
@@ -265,26 +327,15 @@ class ValidatedWorkflow(Workflow):
             if node.id in ready_nodes:
                 continue
 
-            # node might be ready, we have to check all its input edges
-            ready: bool = True
-            node_input_dict: DataMapping = {}
-            for target_key, edge in self.edges_by_target[node.id].items():
-                if edge.source_id in node_outputs:
-                    node_input_dict[target_key] = get_value_at_path(
-                        data=node_outputs[edge.source_id],
-                        path=edge.source_key_path,
-                    )
-                else:
-                    ready = False
-                    break
-            if not ready:
+            node_input = self.get_node_input_if_ready(node.id, node_outputs)
+            if node_input is None:
                 continue
 
             try:
-                ready_nodes[node.id] = node_input_dict
+                ready_nodes[node.id] = node_input
             except ValidationError as e:
                 raise NodeException.for_user(
-                    f"Input {node_input_dict} for node {node.id} is invalid: {e}",
+                    f"Input {node_input} for node {node.id} is invalid: {e}",
                     node=node,
                 ) from e
         return ready_nodes

--- a/src/workflow_engine/execution/parallel.py
+++ b/src/workflow_engine/execution/parallel.py
@@ -112,8 +112,11 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
 
         try:
             try:
-                # Initial dispatch - start all initially ready nodes
-                ready_nodes = {workflow.input_node.id: input}
+                # Initial dispatch - input node plus nodes with no incoming edges
+                ready_nodes = {
+                    **workflow.get_ready_nodes(node_outputs={}),
+                    workflow.input_node.id: input,
+                }
                 for node_id, node_input in ready_nodes.items():
                     task = asyncio.create_task(
                         self._execute_node(

--- a/src/workflow_engine/execution/parallel.py
+++ b/src/workflow_engine/execution/parallel.py
@@ -113,10 +113,7 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
         try:
             try:
                 # Initial dispatch - input node plus nodes with no incoming edges
-                ready_nodes = {
-                    **workflow.get_ready_nodes(node_outputs={}),
-                    workflow.input_node.id: input,
-                }
+                ready_nodes = workflow.get_initial_ready_nodes(input)
                 for node_id, node_input in ready_nodes.items():
                     task = asyncio.create_task(
                         self._execute_node(
@@ -131,7 +128,7 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
                     running_tasks[task] = node_id
 
                 # Main event loop - process completions eagerly
-                while running_tasks or pending_retry:
+                while len(running_tasks) > 0 or len(pending_retry) > 0:
                     # Check if any pending retries are now ready
                     for node_id in list(pending_retry.keys()):
                         state = retry_tracker.get_state(node_id)
@@ -150,13 +147,13 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
                             running_tasks[task] = node_id
 
                     # If no tasks are running but retries are pending, wait for shortest backoff
-                    if not running_tasks and pending_retry:
+                    if len(running_tasks) == 0 and len(pending_retry) > 0:
                         wait_time = retry_tracker.min_wait_time()
                         if wait_time and wait_time.total_seconds() > 0:
                             await asyncio.sleep(wait_time.total_seconds())
                         continue
 
-                    if not running_tasks:
+                    if len(running_tasks) == 0:
                         break
 
                     done, _ = await asyncio.wait(
@@ -166,6 +163,7 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
 
                     # Process completed tasks
                     expansions_pending: list[tuple[str, Workflow]] = []
+                    completed_this_batch: set[str] = set()
 
                     for task in done:
                         node_id = running_tasks.pop(task)
@@ -240,24 +238,31 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
                             failed_nodes.add(node_id)
                         else:
                             node_outputs[node_id] = node_result.result
+                            completed_this_batch.add(node_id)
 
                     # Process expansions sequentially (workflow is immutable)
+                    expanded = len(expansions_pending) > 0
                     for node_id, subgraph in expansions_pending:
                         workflow = workflow.expand_node(node_id, subgraph)
 
-                    # EAGERLY dispatch newly ready nodes
                     in_flight = set(running_tasks.values())
                     pending_set = set(pending_retry.keys())
-                    ready_nodes = {
-                        nid: inp
-                        for nid, inp in workflow.get_ready_nodes(
-                            node_outputs=node_outputs,
-                        ).items()
-                        if nid not in failed_nodes
-                        and nid not in in_flight
-                        and nid not in pending_set
-                        and nid not in node_yields
-                    }
+                    skip = failed_nodes | in_flight | pending_set | set(node_yields)
+
+                    if expanded:
+                        ready_nodes = {
+                            nid: inp
+                            for nid, inp in workflow.get_ready_nodes(
+                                node_outputs=node_outputs,
+                            ).items()
+                            if nid not in skip
+                        }
+                    else:
+                        ready_nodes = workflow.get_ready_successors(
+                            completed_this_batch,
+                            node_outputs,
+                            skip=skip,
+                        )
 
                     for node_id, node_input in ready_nodes.items():
                         task = asyncio.create_task(
@@ -344,7 +349,7 @@ class ParallelExecutionAlgorithm(ExecutionAlgorithm):
         """Cancel all running tasks and wait for completion."""
         for task in running_tasks:
             task.cancel()
-        if running_tasks:
+        if len(running_tasks) > 0:
             await asyncio.wait(running_tasks.keys(), return_when=asyncio.ALL_COMPLETED)
 
     async def _execute_node(

--- a/src/workflow_engine/execution/retry.py
+++ b/src/workflow_engine/execution/retry.py
@@ -86,7 +86,7 @@ class RetryTracker:
             for state in self.states.values()
             if state.next_retry_at is not None and not state.is_ready()
         ]
-        return min(pending) if pending else None
+        return min(pending) if len(pending) > 0 else None
 
 
 __all__ = [

--- a/src/workflow_engine/execution/topological.py
+++ b/src/workflow_engine/execution/topological.py
@@ -74,7 +74,8 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
 
         try:
             try:
-                ready_nodes = {workflow.input_node.id: input}
+                ready_nodes = dict(workflow.get_ready_nodes(node_outputs={}))
+                ready_nodes[workflow.input_node.id] = input
 
                 while len(ready_nodes) > 0 or len(pending_retry) > 0:
                     # Check if any pending retries are now ready

--- a/src/workflow_engine/execution/topological.py
+++ b/src/workflow_engine/execution/topological.py
@@ -74,8 +74,7 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
 
         try:
             try:
-                ready_nodes = dict(workflow.get_ready_nodes(node_outputs={}))
-                ready_nodes[workflow.input_node.id] = input
+                ready_nodes = dict(workflow.get_initial_ready_nodes(input))
 
                 while len(ready_nodes) > 0 or len(pending_retry) > 0:
                     # Check if any pending retries are now ready
@@ -85,7 +84,7 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
                             ready_nodes[node_id] = pending_retry.pop(node_id)
 
                     # If no nodes are ready, wait for the shortest backoff
-                    if not ready_nodes and pending_retry:
+                    if len(ready_nodes) == 0 and len(pending_retry) > 0:
                         wait_time = retry_tracker.min_wait_time()
                         if wait_time and wait_time.total_seconds() > 0:
                             await asyncio.sleep(wait_time.total_seconds())
@@ -104,6 +103,7 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
                     if limiter is not None:
                         await limiter.acquire()
 
+                    expanded = False
                     try:
                         node_result = await node(
                             context=context,
@@ -114,6 +114,7 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
 
                         if isinstance(node_result, ValidatedWorkflow):
                             workflow = workflow.expand_node(node_id, node_result)
+                            expanded = True
                         else:
                             node_outputs[node.id] = node_result
 
@@ -156,14 +157,25 @@ class TopologicalExecutionAlgorithm(ExecutionAlgorithm):
                         if limiter is not None:
                             limiter.release()
 
-                    ready_nodes = {
-                        node_id: node_input
-                        for node_id, node_input in workflow.get_ready_nodes(
-                            node_outputs=node_outputs,
-                            partial_results=ready_nodes,
-                        ).items()
-                        if node_id not in node_yields
-                    }
+                    if expanded:
+                        ready_nodes = {
+                            node_id: node_input
+                            for node_id, node_input in workflow.get_ready_nodes(
+                                node_outputs=node_outputs,
+                                partial_results=ready_nodes,
+                            ).items()
+                            if node_id not in node_yields
+                        }
+                    else:
+                        ready_nodes.update(
+                            workflow.get_ready_successors(
+                                [node_id],
+                                node_outputs,
+                                skip=set(node_outputs)
+                                | set(ready_nodes)
+                                | set(node_yields),
+                            )
+                        )
 
                 if len(node_yields) > 0:
                     partial_output = await workflow.get_output(


### PR DESCRIPTION
Inspired by the execution algorithm improvements from #93, which is easily the most awesome part of that PR. Thanks Claude! Cursor took that outdated PR and distilled it into some DRY-er changes written with Python best practices in mind, which is now what you see here.

This lands the remaining useful changes from #93 in main.

Closes #93

## Summary

- Dispatch all initially-ready nodes at execution start (input node plus dependency-free constants), so parallel and topological executors no longer wait for the input node before starting independent work.
- Add incremental successor-based ready-node tracking to both executors: after each completion, only direct successors are checked via `ValidatedWorkflow.get_ready_successors()`, falling back to a full `get_ready_nodes()` scan only after workflow expansion.
- Factor shared execution helpers onto `ValidatedWorkflow`: `get_node_input_if_ready()`, `get_initial_ready_nodes()`, and `get_ready_successors()`, plus `Workflow.successors_by_source` for graph structure.

## Performance

Benchmarked against main using the autoresearch-style harness (6 workflows × 2 executors, 20 iterations each, all correct):

| Benchmark | Executor | main | perf | Speedup |
|-----------|----------|------|------|---------|
| **large_100** | topological | 22.8 ms | **11.7 ms** | **~1.95×** |
| large_100 | parallel | 11.6 ms | 11.0 ms | ~1.05× |
| parallel_fan | parallel | 1.7 ms | 1.6 ms | ~1.06× |
| retry_chain | topological | 6.1 ms | 4.7 ms | ~1.30× |

Total wall time across all runs: **2.53s → 2.29s** (~9% faster). The largest win is on large DAGs with the topological executor, where the old code rescanned the entire graph after every node completion.

Benchmark script to be attached in a follow-up comment.

## Test plan

- [x] All 675 existing tests pass
- [x] Benchmark harness: 12/12 correctness checks (topological + parallel × 6 workflows)
- [x] pyright clean on changed files


Made with [Cursor](https://cursor.com)