### PR TITLE
Fix StakeholderLevel __le__/__ge__ to match semantic ordering (#176)

### DIFF
--- a/src/workflow_engine/core/stakeholder.py
+++ b/src/workflow_engine/core/stakeholder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import StrEnum
 
 
@@ -24,11 +26,17 @@ class StakeholderLevel(StrEnum):
     # Runs workflows built by builders.
     USER = "USER"
 
-    def __lt__(self, other: "StakeholderLevel") -> bool:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __lt__(self, other: StakeholderLevel) -> bool:  # pyright: ignore[reportIncompatibleMethodOverride]
         return _STAKEHOLDER_LEVELS.index(self) < _STAKEHOLDER_LEVELS.index(other)
 
-    def __gt__(self, other: "StakeholderLevel") -> bool:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __le__(self, other: StakeholderLevel) -> bool:  # pyright: ignore[reportIncompatibleMethodOverride]
+        return _STAKEHOLDER_LEVELS.index(self) <= _STAKEHOLDER_LEVELS.index(other)
+
+    def __gt__(self, other: StakeholderLevel) -> bool:  # pyright: ignore[reportIncompatibleMethodOverride]
         return _STAKEHOLDER_LEVELS.index(self) > _STAKEHOLDER_LEVELS.index(other)
+
+    def __ge__(self, other: StakeholderLevel) -> bool:  # pyright: ignore[reportIncompatibleMethodOverride]
+        return _STAKEHOLDER_LEVELS.index(self) >= _STAKEHOLDER_LEVELS.index(other)
 
 
 _STAKEHOLDER_LEVELS = (

--- a/tests/test_stakeholder.py
+++ b/tests/test_stakeholder.py
@@ -1,0 +1,39 @@
+import pytest
+
+from workflow_engine.core.stakeholder import StakeholderLevel
+
+pytestmark = pytest.mark.unit
+
+# Semantic order from most to least powerful.
+_ORDERED = (
+    StakeholderLevel.ENGINEER,
+    StakeholderLevel.OPERATOR,
+    StakeholderLevel.BUILDER,
+    StakeholderLevel.USER,
+)
+
+
+def test_strict_ordering_matches_semantic_order():
+    for i, lower in enumerate(_ORDERED):
+        for higher in _ORDERED[i + 1 :]:
+            assert lower < higher
+            assert higher > lower
+            assert not (higher < lower)
+            assert not (lower > higher)
+
+
+def test_non_strict_ordering_agrees_with_strict():
+    for i, lower in enumerate(_ORDERED):
+        for higher in _ORDERED[i + 1 :]:
+            assert lower <= higher
+            assert higher >= lower
+            assert not (higher <= lower)
+            assert not (lower >= higher)
+
+
+def test_non_strict_ordering_reflexive():
+    for level in _ORDERED:
+        assert level <= level
+        assert level >= level
+        assert not (level < level)
+        assert not (level > level)


### PR DESCRIPTION
Implements `__le__`/`__ge__` on `StakeholderLevel` using the same rank ordering as the existing `__lt__`/`__gt__` overrides. They were previously inherited from `StrEnum` and compared alphabetically, so `a > b` could be True while `a >= b` was False.

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)