### PR TITLE
Block releases without a matching CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project uses [PEP 440](https://peps.python.org/pep-0440/) versioning with r
 - `NodeRegistry.extend()` now handles reregistration correctly (#180).
 - `StakeholderLevel.__le__` / `__ge__` now match the semantic ordering (#176, #179).
 
+### Internal
+
+- `release.sh` now aborts if `CHANGELOG.md` has no section for the version being released, so releases can't be tagged without documented changes (#173).
+
 ## [2.0.0rc14] - 2026-07-02
 
 ### Added

--- a/release.sh
+++ b/release.sh
@@ -141,6 +141,13 @@ fi
 
 echo "New version: $NEW_VERSION"
 
+# Ensure the changelog has a matching section for this version
+if ! grep -qE "^## \[${NEW_VERSION//./\\.}\]" CHANGELOG.md; then
+    echo "Error: CHANGELOG.md has no '## [$NEW_VERSION]' section."
+    echo "Add a changelog entry for $NEW_VERSION before releasing."
+    exit 1
+fi
+
 # Get commit history since last tag
 echo ""
 echo "Changes since $LATEST_TAG:"
@@ -155,6 +162,13 @@ read -p "Proceed with release v$NEW_VERSION? [y/N] " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "Aborted."
+    exit 1
+fi
+
+# Ensure CHANGELOG.md has a matching section for this version
+if ! grep -qE "^## \[${NEW_VERSION//./\\.}\]" CHANGELOG.md; then
+    echo "Error: CHANGELOG.md has no '## [$NEW_VERSION]' section."
+    echo "Add a changelog entry for $NEW_VERSION before releasing."
     exit 1
 fi
 

--- a/release.sh
+++ b/release.sh
@@ -165,13 +165,6 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 1
 fi
 
-# Ensure CHANGELOG.md has a matching section for this version
-if ! grep -qE "^## \[${NEW_VERSION//./\\.}\]" CHANGELOG.md; then
-    echo "Error: CHANGELOG.md has no '## [$NEW_VERSION]' section."
-    echo "Add a changelog entry for $NEW_VERSION before releasing."
-    exit 1
-fi
-
 # Update version in pyproject.toml and __init__.py
 echo "Updating version to $NEW_VERSION..."
 sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml


### PR DESCRIPTION
Adds a guard to `release.sh` that aborts before any changes are made if `CHANGELOG.md` has no `## [<version>]` section for the version being cut. This prevents the class of gap that produced #173 (rc8–rc10 shipped with no changelog entries).

The check runs after the version is computed/confirmed and before the version bump, tests, tag, and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)